### PR TITLE
New: Process http headers from mapping blocks for each http method.

### DIFF
--- a/grails-datastore-gorm-rest-client/src/main/groovy/org/grails/datastore/mapping/rest/client/engine/RestClientEntityPersister.groovy
+++ b/grails-datastore-gorm-rest-client/src/main/groovy/org/grails/datastore/mapping/rest/client/engine/RestClientEntityPersister.groovy
@@ -88,6 +88,9 @@ class RestClientEntityPersister extends EntityPersister {
 
                 promiseList << asyncRestBuilder.get(url, args) {
                     accept endpoint.acceptType ?: pe.javaClass, endpoint.accept
+                    for (entry in endpoint.headers.entrySet()) {
+                        header entry.key, entry.value
+                    }
                     if(sessionRequestCustomizer instanceof Closure) {
                         Closure callable = (Closure)sessionRequestCustomizer
                         callable.delegate = delegate
@@ -113,6 +116,9 @@ class RestClientEntityPersister extends EntityPersister {
 
                 responseResults <<  builder.get(url, args) {
                     accept endpoint.acceptType ?: pe.javaClass, endpoint.accept
+                    for (entry in endpoint.headers.entrySet()) {
+                        header entry.key, entry.value
+                    }
                     if(sessionRequestCustomizer instanceof Closure) {
                         Closure callable = (Closure)sessionRequestCustomizer
                         callable.delegate = delegate
@@ -168,6 +174,9 @@ class RestClientEntityPersister extends EntityPersister {
                             Promise<RestResponse> updatePromise = builder.put(url) {
                                 contentType endpoint.contentType
                                 accept endpoint.acceptType ?: entity.javaClass, endpoint.accept
+                                for (entry in endpoint.headers.entrySet()) {
+                                    header entry.key, entry.value
+                                }
                                 body update
                             }.then { RestResponse response ->
                                 if(response.statusCode.series() == HttpStatus.Series.SUCCESSFUL) {
@@ -206,6 +215,9 @@ class RestClientEntityPersister extends EntityPersister {
                     Promise<RestResponse> insertPromise = restBuilder.post(url) {
                         contentType endpoint.contentType
                         accept endpoint.acceptType ?: entity.javaClass, endpoint.accept
+                        for (entry in endpoint.headers.entrySet()) {
+                            header entry.key, entry.value
+                        }
                         body insert
                     }.then { RestResponse response ->
                         if(response.statusCode.series() == HttpStatus.Series.SUCCESSFUL) {
@@ -270,6 +282,9 @@ class RestClientEntityPersister extends EntityPersister {
             AsyncRestBuilder builder = datastore.asyncRestClients.get(pe)
             Promise<RestResponse> promise = builder.get(url, args) {
                 accept endpoint.acceptType ?: pe.javaClass, endpoint.accept
+                for (entry in endpoint.headers.entrySet()) {
+                    header entry.key, entry.value
+                }
                 if(sessionRequestCustomizer instanceof Closure) {
                     Closure callable = (Closure)sessionRequestCustomizer
                     callable.delegate = delegate
@@ -287,6 +302,9 @@ class RestClientEntityPersister extends EntityPersister {
             RestBuilder builder = datastore.syncRestClients.get(pe)
             response = builder.get(url, args) {
                 accept endpoint.acceptType ?: pe.javaClass, endpoint.accept
+                for (entry in endpoint.headers.entrySet()) {
+                    header entry.key, entry.value
+                }
                 if(sessionRequestCustomizer instanceof Closure) {
                     Closure callable = (Closure)sessionRequestCustomizer
                     callable.delegate = delegate
@@ -367,6 +385,9 @@ class RestClientEntityPersister extends EntityPersister {
                         Promise<RestResponse> responsePromise = builder.put(url, args) {
                             contentType endpoint.contentType
                             accept endpoint.acceptType ?: pe.javaClass, endpoint.accept
+                            for (entry in endpoint.headers.entrySet()) {
+                                header entry.key, entry.value
+                            }
                             body obj
                             if(sessionRequestCustomizer instanceof Closure) {
                                 Closure callable = (Closure)sessionRequestCustomizer
@@ -399,6 +420,9 @@ class RestClientEntityPersister extends EntityPersister {
                 final RestResponse response = restBuilder.put(url, args) {
                     contentType endpoint.contentType
                     accept endpoint.acceptType ?: pe.javaClass, endpoint.accept
+                    for (entry in endpoint.headers.entrySet()) {
+                        header entry.key, entry.value
+                    }
                     body obj
                     if(sessionRequestCustomizer instanceof Closure) {
                         Closure callable = (Closure)sessionRequestCustomizer
@@ -461,6 +485,9 @@ class RestClientEntityPersister extends EntityPersister {
             Promise<RestResponse> result = builder.post(url) {
                 contentType endpoint.contentType
                 accept endpoint.acceptType ?: pe.javaClass, endpoint.accept
+                for (entry in endpoint.headers.entrySet()) {
+                    header entry.key, entry.value
+                }
                 body obj
                 if(sessionRequestCustomizer instanceof Closure) {
                     Closure callable = (Closure)sessionRequestCustomizer
@@ -484,6 +511,9 @@ class RestClientEntityPersister extends EntityPersister {
             response = builder.post(url) {
                 contentType endpoint.contentType
                 accept endpoint.acceptType ?: pe.javaClass, endpoint.accept
+                for (entry in endpoint.headers.entrySet()) {
+                    header entry.key, entry.value
+                }
                 body obj
                 if(sessionRequestCustomizer instanceof Closure) {
                     Closure callable = (Closure)sessionRequestCustomizer
@@ -566,7 +596,16 @@ class RestClientEntityPersister extends EntityPersister {
                     AsyncRestBuilder builder = datastore.asyncRestClients.get(pe)
                     Map<String, Object> args = [:]
                     args.put('id', id)
-                    Promise<RestResponse> result = builder.delete(url, args, (Closure)sessionRequestCustomizer).then { RestResponse response ->
+                    Promise<RestResponse> result = builder.delete(url, args) {
+                        for (entry in endpoint.headers.entrySet()) {
+                            header entry.key, entry.value
+                        }
+                        if(sessionRequestCustomizer instanceof Closure) {
+                            Closure callable = (Closure)sessionRequestCustomizer
+                            callable.delegate = delegate
+                            callable.call()
+                        }
+                    }.then { RestResponse response ->
                         if(response.statusCode.series() == HttpStatus.Series.SUCCESSFUL) {
                             firePostDeleteEvent(pe, entityAccess)
                         }
@@ -588,7 +627,16 @@ class RestClientEntityPersister extends EntityPersister {
                     RestBuilder builder = datastore.syncRestClients.get(pe)
                     Map<String, Object> args = [:]
                     args.put('id', id)
-                    RestResponse response = builder.delete(url, args, (Closure)sessionRequestCustomizer)
+                    RestResponse response = builder.delete(url, args) {
+                        for (entry in endpoint.headers.entrySet()) {
+                            header entry.key, entry.value
+                        }
+                        if(sessionRequestCustomizer instanceof Closure) {
+                            Closure callable = (Closure)sessionRequestCustomizer
+                            callable.delegate = delegate
+                            callable.call()
+                        }
+                    }
                     if(response.statusCode.series() != HttpStatus.Series.SUCCESSFUL) {
                         throw new RestClientException("Invalid status code [${response.statusCode}] returned for DELETE request to URL [$url]", response)
                     }
@@ -616,7 +664,11 @@ class RestClientEntityPersister extends EntityPersister {
                 final id = getObjectIdentifier(obj)
                 if(id) {
                     final url = establishUrl(datastore.baseUrl, endpoint, pe, id)
-                    Promise<RestResponse> deletePromise = restBuilder.delete(url)
+                    Promise<RestResponse> deletePromise = restBuilder.delete(url) {
+                        for (entry in endpoint.headers.entrySet()) {
+                            header entry.key, entry.value
+                        }
+                    }
                     deletePromise.then { RestResponse response ->
                         if(response && response.statusCode.series() == HttpStatus.Series.SUCCESSFUL)
                             firePostDeleteEvent(pe, new EntityAccess(pe, obj))

--- a/grails-datastore-gorm-rest-client/src/main/groovy/org/grails/datastore/mapping/rest/client/query/RequestParameterRestClientQuery.groovy
+++ b/grails-datastore-gorm-rest-client/src/main/groovy/org/grails/datastore/mapping/rest/client/query/RequestParameterRestClientQuery.groovy
@@ -79,6 +79,9 @@ class RequestParameterRestClientQuery extends Query {
                 AsyncRestBuilder builder = datastore.asyncRestClients.get(entity)
                 Promise<RestResponse> promise = builder.get(urlBuilder.toString()) {
                     accept List, endpoint.accept
+                    for (entry in endpoint.headers.entrySet()) {
+                        header entry.key, entry.value
+                    }
                 }
                 if (endpoint.readTimeout > -1) {
                     response = promise.get(endpoint.readTimeout, TimeUnit.SECONDS)
@@ -91,6 +94,9 @@ class RequestParameterRestClientQuery extends Query {
                 RestBuilder builder = datastore.syncRestClients.get(entity)
                 response = builder.get(urlBuilder.toString()) {
                     accept List, endpoint.accept
+                    for (entry in endpoint.headers.entrySet()) {
+                        header entry.key, entry.value
+                    }
                 }
             }
 

--- a/grails-datastore-gorm-rest-client/src/test/groovy/org/grails/datastore/gorm/rest/client/json/CrudJsonSpec.groovy
+++ b/grails-datastore-gorm-rest-client/src/test/groovy/org/grails/datastore/gorm/rest/client/json/CrudJsonSpec.groovy
@@ -29,6 +29,8 @@ class CrudJsonSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.GET))
                     .andExpect(header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON.toString()))
                     .andRespond(withSuccess('[{"id":1, "title":"The Stand", "pages":200}]', MediaType.APPLICATION_JSON))
@@ -48,6 +50,8 @@ class CrudJsonSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book?offset=5&max=10"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.GET))
                     .andExpect(header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON.toString()))
                     .andRespond(withSuccess('[{"id":1, "title":"The Stand", "pages":200}]', MediaType.APPLICATION_JSON))
@@ -67,6 +71,8 @@ class CrudJsonSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book/1"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                       .andExpect(method(HttpMethod.GET))
                       .andExpect(header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON.toString()))
                       .andRespond(withSuccess('{"id":1, "title":"The Stand", "pages":200}', MediaType.APPLICATION_JSON))
@@ -87,6 +93,8 @@ class CrudJsonSpec extends RestClientDatastoreSpec{
         RestTemplate rt = Book.getRestBuilder().restTemplate
         final mockServer = MockRestServiceServer.createServer(rt)
         mockServer.expect(requestTo("http://localhost:8080/book-custom/1"))
+                .andExpect(header("user", "apiUser"))
+                .andExpect(header("pass", "apiPass"))
                 .andExpect(header('Foo', 'Bar'))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON.toString()))
@@ -110,6 +118,8 @@ class CrudJsonSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book/1"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.GET))
                     .andExpect(header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON.toString()))
                     .andRespond(withSuccess('{"id":1, "title":"The Stand", "pages":200}', MediaType.APPLICATION_JSON))
@@ -131,12 +141,16 @@ class CrudJsonSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.POST))
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                     .andExpect(content().string('{"class":"org.grails.datastore.gorm.rest.client.json.Book","id":null,"pages":null,"title":"The Stand"}'))
                     .andRespond(withSuccess('{"id":1, "title":"The Stand"}', MediaType.APPLICATION_JSON))
 
             mockServer.expect(requestTo("http://localhost:8080/book/2"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.PUT))
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                     .andExpect(content().string('{"class":"org.grails.datastore.gorm.rest.client.json.Book","id":2,"pages":null,"title":"The Shining"}'))
@@ -165,6 +179,8 @@ class CrudJsonSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.POST))
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                     .andExpect(content().string('{"class":"org.grails.datastore.gorm.rest.client.json.Book","id":null,"pages":null,"title":"The Stand"}'))
@@ -184,6 +200,8 @@ class CrudJsonSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/other-books"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(header('Foo', 'Bar'))
                     .andExpect(method(HttpMethod.POST))
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
@@ -207,6 +225,8 @@ class CrudJsonSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.POST))
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                     .andExpect(content().string('{"class":"org.grails.datastore.gorm.rest.client.json.Book","id":1,"pages":null,"title":"The Stand"}'))
@@ -227,6 +247,8 @@ class CrudJsonSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book/1"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.PUT))
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                     .andExpect(content().string('{"class":"org.grails.datastore.gorm.rest.client.json.Book","id":1,"pages":null,"title":"The Stand"}'))
@@ -247,6 +269,8 @@ class CrudJsonSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book-custom/1"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.PUT))
                     .andExpect(header('Foo', 'Bar'))
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
@@ -271,6 +295,8 @@ class CrudJsonSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book/1"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.DELETE))
                     .andRespond(withStatus(HttpStatus.NO_CONTENT))
 
@@ -289,6 +315,8 @@ class CrudJsonSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book/1"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.DELETE))
                     .andRespond(withStatus(HttpStatus.NO_CONTENT))
 
@@ -321,5 +349,6 @@ class Book {
 
     static mapping = {
 //        async false
+        headers user: "apiUser", pass: "apiPass"
     }
 }

--- a/grails-datastore-gorm-rest-client/src/test/groovy/org/grails/datastore/gorm/rest/client/xml/CrudXmlSpec.groovy
+++ b/grails-datastore-gorm-rest-client/src/test/groovy/org/grails/datastore/gorm/rest/client/xml/CrudXmlSpec.groovy
@@ -21,6 +21,8 @@ class CrudXmlSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book/1"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.GET))
                     .andExpect(header(HttpHeaders.ACCEPT, MediaType.APPLICATION_XML.toString()))
                     .andRespond(withSuccess('<book id="1"><title>The Stand</title><pages>200</pages></book>', MediaType.APPLICATION_XML))
@@ -41,6 +43,8 @@ class CrudXmlSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book/1"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.GET))
                     .andExpect(header(HttpHeaders.ACCEPT, MediaType.APPLICATION_XML.toString()))
                     .andRespond(withSuccess('<book id="1"><title>The Stand</title><pages>200</pages></book>', MediaType.APPLICATION_XML))
@@ -62,12 +66,16 @@ class CrudXmlSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.POST))
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
                     .andExpect(content().string('<?xml version="1.0" encoding="UTF-8"?><book><pages /><title>The Stand</title></book>'))
                     .andRespond(withSuccess('<book id="1"><title>The Stand</title><pages>200</pages></book>', MediaType.APPLICATION_XML))
     
             mockServer.expect(requestTo("http://localhost:8080/book/2"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.PUT))
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
                     .andExpect(content().string('<?xml version="1.0" encoding="UTF-8"?><book id="2"><pages /><title>The Shining</title></book>'))
@@ -96,6 +104,8 @@ class CrudXmlSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.POST))
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
                     .andExpect(content().string('<?xml version="1.0" encoding="UTF-8"?><book><pages /><title>The Stand</title></book>'))
@@ -115,6 +125,8 @@ class CrudXmlSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.POST))
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
                     .andExpect(content().string('<?xml version="1.0" encoding="UTF-8"?><book id="1"><pages /><title>The Stand</title></book>'))
@@ -135,6 +147,8 @@ class CrudXmlSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book/1"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.PUT))
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
                     .andExpect(content().string('<?xml version="1.0" encoding="UTF-8"?><book id="1"><pages /><title>The Stand</title></book>'))
@@ -155,6 +169,8 @@ class CrudXmlSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book/1"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.DELETE))
                     .andRespond(withStatus(HttpStatus.NO_CONTENT))
 
@@ -173,6 +189,8 @@ class CrudXmlSpec extends RestClientDatastoreSpec{
             RestTemplate rt = Book.getRestBuilder().restTemplate
             final mockServer = MockRestServiceServer.createServer(rt)
             mockServer.expect(requestTo("http://localhost:8080/book/1"))
+                    .andExpect(header("user", "apiUser"))
+                    .andExpect(header("pass", "apiPass"))
                     .andExpect(method(HttpMethod.DELETE))
                     .andRespond(withStatus(HttpStatus.NO_CONTENT))
 
@@ -206,6 +224,7 @@ class Book {
     static mapping = {
         contentType "application/xml"
         accept "application/xml"
+        headers user: "apiUser", pass: "apiPass"
 //        async false
     }
 }


### PR DESCRIPTION
Hi Graeme,

I came across an issue with the "headers" directive from DomainClass/default mapping blocks which were not picked up when processing the request customizer.

Would be great if you'd consider to merge it in as we plan to use this plugin for production.

Best regards,
Patrick
