### PR TITLE
Update RestBuilder.groovy

### DIFF
--- a/grails-datastore-rest-client/src/main/groovy/grails/plugins/rest/client/RestBuilder.groovy
+++ b/grails-datastore-rest-client/src/main/groovy/grails/plugins/rest/client/RestBuilder.groovy
@@ -291,6 +291,10 @@ class RestBuilder {
         if(stringConverter) {
             messageConverters.remove(stringConverter)
         }
+        final mappingJackson2HttpMessageConverter = messageConverters.find { HttpMessageConverter httpMessageConverter -> httpMessageConverter instanceof MappingJackson2HttpMessageConverter }
+        if(mappingJackson2HttpMessageConverter) {
+            messageConverters.remove(mappingJackson2HttpMessageConverter)
+        }
         if(ClassUtils.isPresent("com.google.gson.Gson", getClass().getClassLoader())) {
             messageConverters.add(new GsonHttpMessageConverter())
         }


### PR DESCRIPTION
RestBuilder get request for JSON resources fails if Jackson is present on the classpath. MappingJackson2HttpMessageConverter is now removed from restTemplate.messageConverters if present.
