### PR TITLE
remove obsolete note from javadoc.

### DIFF
--- a/grails-datastore-gorm-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/metaclass/AbstractDynamicPersistentMethod.java
+++ b/grails-datastore-gorm-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/metaclass/AbstractDynamicPersistentMethod.java
@@ -86,8 +86,7 @@ public abstract class AbstractDynamicPersistentMethod extends AbstractDynamicMet
     /**
      * Initializes the Errors property on target.  The target will be assigned a new
      * Errors property.  If the target contains any binding errors, those binding
-     * errors will be copied in to the new Errors property.  Note that the binding errors
-     * will no longer be flagged as binding errors
+     * errors will be copied in to the new Errors property.
      *
      * @param target object to initialize
      * @return the new Errors object

--- a/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/metaclass/AbstractDynamicPersistentMethod.java
+++ b/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/metaclass/AbstractDynamicPersistentMethod.java
@@ -91,8 +91,7 @@ public abstract class AbstractDynamicPersistentMethod extends AbstractDynamicMet
     /**
      * Initializes the Errors property on target.  The target will be assigned a new
      * Errors property.  If the target contains any binding errors, those binding
-     * errors will be copied in to the new Errors property.  Note that the binding errors
-     * will no longer be flagged as binding errors
+     * errors will be copied in to the new Errors property.
      *
      * @param target object to initialize
      * @return the new Errors object


### PR DESCRIPTION
The note was obsoleted by https://github.com/grails/grails-data-mapping/commit/4540ded5cf99a3c045b9f9310021261c389de2a7 since its copied binding errors remain flagged as binding errors.
