### PR TITLE
Fix for multiple datasources and grails plugin datastores

### DIFF
--- a/grails-datastore-gorm-plugin-support/src/main/groovy/org/grails/datastore/gorm/plugin/support/PersistenceContextInterceptorAggregator.groovy
+++ b/grails-datastore-gorm-plugin-support/src/main/groovy/org/grails/datastore/gorm/plugin/support/PersistenceContextInterceptorAggregator.groovy
@@ -109,7 +109,6 @@ class PersistenceContextInterceptorAggregator implements BeanDefinitionRegistryP
             def interceptor = hibernateAggregatePersistenceContextInterceptor.newInstance()
             interceptor.applicationContext = applicationContext
             interceptor.afterPropertiesSet()
-            // interceptor.sessionFactory = beanFactory.getBean('sessionFactory')
             interceptors << interceptor
         }
 


### PR DESCRIPTION
An issue existed with all plugin grails adaptors for GORM (particularly mongo) and multiple hibernate datasources. The persistenceInterceptor gets replaced by the SpringConfigurer with the  PersistenceContextInterceptorAggregator which aggregates the interceptors into one. It unfortunately did not redefine the hibernate interceptor correctly and only used the single data source aware interceptor for the default datasource. This constructs and appends the `org.codehaus.groovy.grails.orm.hibernate.support.AggregatePersistenceContextInterceptor`

http://jira.grails.org/browse/GPMONGODB-357
