### PR TITLE
Resolves Issue GRAILS-10982 - findWhere and findAllWhere not accepting GString Keys

### DIFF
--- a/grails-datastore-gorm-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/HibernateGormStaticApi.groovy
+++ b/grails-datastore-gorm-hibernate/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/HibernateGormStaticApi.groovy
@@ -386,7 +386,9 @@ class HibernateGormStaticApi<D> extends GormStaticApi<D> {
     List<D> findAllWhere(Map queryMap, Map args) {
         if (!queryMap) return null
         (List<D>)hibernateTemplate.execute({Session session ->
-            Map queryArgs = filterQueryArgumentMap(queryMap)
+            Map<String, Object> processedQueryMap = [:]
+            queryMap.each{ key, value -> processedQueryMap[key.toString()] = value }
+            Map queryArgs = filterQueryArgumentMap(processedQueryMap)
             List<String> nullNames = removeNullNames(queryArgs)
             Criteria criteria = session.createCriteria(persistentClass)
             hibernateTemplate.applySettings(criteria)
@@ -403,7 +405,9 @@ class HibernateGormStaticApi<D> extends GormStaticApi<D> {
     D findWhere(Map queryMap, Map args) {
         if (!queryMap) return null
         (D)hibernateTemplate.execute({Session session ->
-            Map queryArgs = filterQueryArgumentMap(queryMap)
+            Map<String, Object> processedQueryMap = [:]
+            queryMap.each{ key, value -> processedQueryMap[key.toString()] = value }
+            Map queryArgs = filterQueryArgumentMap(processedQueryMap)
             List<String> nullNames = removeNullNames(queryArgs)
             Criteria criteria = session.createCriteria(persistentClass)
             hibernateTemplate.applySettings(criteria)

--- a/grails-datastore-gorm-neo4j/src/test/groovy/grails/gorm/tests/FindWhereSpec.groovy
+++ b/grails-datastore-gorm-neo4j/src/test/groovy/grails/gorm/tests/FindWhereSpec.groovy
@@ -40,6 +40,13 @@ class FindWhereSpec extends GormDatastoreSpec {
         Person.findWhere((property): 'Brown').lastName == 'Brown'
     }
 
+    void 'findWhere with GString property'() {
+        when:
+        def property='lastName'
+        then:
+        Person.findWhere("${property}":'Brown').lastName == 'Brown'
+    }
+
 }
 
 

--- a/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/FindWhereSpec.groovy
+++ b/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/FindWhereSpec.groovy
@@ -1,0 +1,61 @@
+package grails.gorm.tests
+
+class FindWhereSpec extends GormDatastoreSpec {
+
+    def "Test findWhere returns a matching Instance"() {
+        given:
+            def entityId = new TestEntity(name: 'David', age: 27).save().id
+
+
+        when:
+            def entity = TestEntity.findWhere(name: 'David')
+
+        then:
+            'David' == entity.name
+            27 == entity.age
+            entityId == entity.id
+    }
+
+    def "Test findWhere with a GString property"() {
+        given:
+            def entityId = new TestEntity(name: 'David', age: 27).save().id
+            def property = "name"
+
+        when:
+            def entity = TestEntity.findWhere("${property}": 'David')
+
+        then:
+            'David' == entity.name
+            27 == entity.age
+            entityId == entity.id
+    }
+
+    def "Test findAllWhere returns a matching Instance"() {
+        given:
+            def entityId = new TestEntity(name: 'David', age: 27).save().id
+
+
+        when:
+            def entity = TestEntity.findAllWhere(name: 'David')
+        then:
+            'David' == entity[0].name
+            27 == entity[0].age
+            entityId == entity[0].id
+    }
+
+    def "Test findAllWhere with a GString property"() {
+        given:
+            def entityId = new TestEntity(name: 'David', age: 27).save().id
+            def property = "name"
+
+        when:
+            def entity = TestEntity.findAllWhere("${property}": 'David')
+
+        then:
+            'David' == entity[0].name
+            27 == entity[0].age
+            entityId == entity[0].id
+    }
+
+
+}

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormStaticApi.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormStaticApi.groovy
@@ -576,7 +576,11 @@ class GormStaticApi<D> extends AbstractGormApi<D> {
     List<D> findAllWhere(Map queryMap, Map args) {
         (List<D>)execute ({ Session session ->
             Query q = session.createQuery(persistentClass)
-            q.allEq(queryMap)
+
+            Map<String, Object> processedQueryMap = [:]
+            queryMap.each{ key, value -> processedQueryMap[key.toString()] = value }
+            q.allEq(processedQueryMap)
+            
             DynamicFinder.populateArgumentsForCriteria persistentClass, q, args
             q.list()
         } as SessionCallback<List>)
@@ -630,7 +634,9 @@ class GormStaticApi<D> extends AbstractGormApi<D> {
         execute({ Session session ->
             Query q = session.createQuery(persistentClass)
             if (queryMap) {
-                q.allEq(queryMap)
+                Map<String, Object> processedQueryMap = [:]
+                queryMap.each{ key, value -> processedQueryMap[key.toString()] = value }
+                q.allEq(processedQueryMap)
             }
             DynamicFinder.populateArgumentsForCriteria persistentClass, q, args
             q.singleResult()


### PR DESCRIPTION
This fixes the findAllWhere and findWhere, An Issue existed where a call like this

``` groovy
def property = "name"
TestEntity.findWhere("${property}":"David")
TestEntity.findAllWhere("${property}":"David")
//Exception Thrown Class Cast Exception
```

This is Resolved , tests were also added to tck project (FindWhereSpec) which provides a few tests for the findWhere method and findAllWhere method.
