### PR TITLE
Null safe get original value

### DIFF
--- a/grails-datastore-gorm/src/test/groovy/org/grails/datastore/gorm/dirty/checking/DirtyCheckTransformationSpec.groovy
+++ b/grails-datastore-gorm/src/test/groovy/org/grails/datastore/gorm/dirty/checking/DirtyCheckTransformationSpec.groovy
@@ -99,6 +99,17 @@ class FundProduct {
             b.hasChanged("author")
 
     }
+
+    void "Test that dirty checking transformation doesn't allow for NPE for new objects"(){
+			given: "A new book is created"
+				def book = new Book()
+
+			when: "Title is set"
+				book.title = "Title"
+
+			then: "getOrginal Value returns null"
+				book.getOriginalValue('title') == null
+		}
 }
 
 @DirtyCheck


### PR DESCRIPTION
For new objects getOrginalValue should return null not through a NPE.

https://jira.grails.org/browse/GRAILS-11422
