### PR TITLE
GPMONGODB-380 Fix for finders using disjunctions with persistent types

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/Query.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/Query.java
@@ -128,6 +128,16 @@ public abstract class Query implements Cloneable{
      */
     public void add(Criterion criterion) {
         Junction currentJunction = criteria;
+        add(currentJunction, criterion);
+    }
+
+    /**
+     * Adds the specified criterion instance to the given junction
+     *
+     * @param currentJunction The junction to add the criterion to
+     * @param criterion The criterion instance
+     */
+    public void add(Junction currentJunction, Criterion criterion) {
         addToJunction(currentJunction, criterion);
     }
 
@@ -155,7 +165,7 @@ public abstract class Query implements Cloneable{
     }
 
     /**
-     * Creates a disjunction (OR) query
+     * Creates a conjunction (AND) query
      * @return The Junction instance
      */
     public Junction conjunction() {
@@ -600,9 +610,9 @@ public abstract class Query implements Cloneable{
     }
 
     private Junction conjunction(Junction currentJunction) {
-        Conjunction dis = new Conjunction();
-        currentJunction.add(dis);
-        return dis;
+        Conjunction con = new Conjunction();
+        currentJunction.add(con);
+        return con;
     }
 
     /**

--- a/grails-datastore-gorm-mongodb/src/test/groovy/org/grails/datastore/gorm/mongo/DisjunctionQuerySpec.groovy
+++ b/grails-datastore-gorm-mongodb/src/test/groovy/org/grails/datastore/gorm/mongo/DisjunctionQuerySpec.groovy
@@ -1,0 +1,64 @@
+package org.grails.datastore.gorm.mongo
+
+import grails.gorm.tests.GormDatastoreSpec
+import grails.gorm.tests.Pet
+import grails.gorm.tests.PetType
+import spock.lang.Issue
+
+class DisjunctionQuerySpec extends GormDatastoreSpec {
+    def dogType
+    def catType
+    def birdType
+
+    @Issue('GPMONGODB-380')
+    void "Find all pets of type cat or of type dog"() {
+        given: "Some data"
+            loadTestData()
+
+        when:"All pets with type of dog or name of Jack are retrieved"
+            def results = Pet.findAllByTypeOrName(dogType, 'Jack')
+
+        then:"The correct number of pets were found"
+            results.size() == 3
+
+        and:"The correct pets were found"
+            results.find { it.name == "Rocco"}
+            results.find { it.name == "Max"}
+            results.find { it.name == "Jack"}
+    }
+
+    @Issue('GPMONGODB-380')
+    void "Find only pets of bird type or bird type"() {
+        given: "Some data"
+            loadTestData()
+            
+        when:"Only bird type or bird type pets are retrieved"
+            def pet = Pet.findByTypeOrType(birdType, birdType)
+
+        then:"The correct pet is returned"
+            pet != null
+            pet.name == "Big Bird"
+    }
+
+    @Issue('GPMONGODB-380')
+    void "Count all dogs or pets with the name Jack"() {
+        given: "Some data"
+            loadTestData()
+            
+        expect:
+            Pet.countByTypeOrName(dogType, 'Jack') == 3
+    }
+
+    private void loadTestData() {
+        dogType = new PetType(name: 'dog').save()
+        catType = new PetType(name: 'cat').save()
+        birdType = new PetType(name: 'bird').save()
+
+        new Pet(name:"Rocco", type: dogType).save()
+        new Pet(name:"Max", type: dogType).save()
+        new Pet(name:"Jack", type: catType).save()
+        new Pet(name:"Big Bird", type: birdType).save(flush:true)
+        
+        session.clear()
+    }
+}

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/AbstractFindByFinder.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/AbstractFindByFinder.java
@@ -59,7 +59,7 @@ public abstract class AbstractFindByFinder extends DynamicFinder {
             Query.Junction disjunction = q.disjunction();
 
             for (MethodExpression expression : invocation.getExpressions()) {
-                disjunction.add(expression.createCriterion());
+                q.add(disjunction, expression.createCriterion());
             }
         }
         else {

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/CountByFinder.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/CountByFinder.java
@@ -61,7 +61,7 @@ public class CountByFinder extends DynamicFinder implements QueryBuildingFinder 
             Query.Junction disjunction = q.disjunction();
 
             for (MethodExpression expression : invocation.getExpressions()) {
-                disjunction.add(expression.createCriterion());
+                q.add(disjunction, expression.createCriterion());
             }
         }
         else {

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/FindAllByFinder.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/FindAllByFinder.java
@@ -69,7 +69,7 @@ public class FindAllByFinder extends DynamicFinder {
             Query.Junction disjunction = q.disjunction();
 
             for (MethodExpression expression : invocation.getExpressions()) {
-                disjunction.add(expression.createCriterion());
+                q.add(disjunction, expression.createCriterion());
             }
         }
         else {


### PR DESCRIPTION
A potential fix and tests for GPMONGODB-380. The issue with the disjunctions is that they are not being sent through the addToJunction method in Query.
