### PR TITLE
Work with SpringSessionSynchronization changes from Spring 4.1.0.RC2

### DIFF
--- a/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/GrailsSessionContext.java
+++ b/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/GrailsSessionContext.java
@@ -231,8 +231,13 @@ public class GrailsSessionContext implements CurrentSessionContext {
     protected void lookupConstructors() {
         springFlushSynchronizationConstructor = lookupConstructor(
                 "org.springframework.orm.hibernate4.SpringFlushSynchronization", Session.class);
-        springSessionSynchronizationConstructor = lookupConstructor(
+        try{
+            springSessionSynchronizationConstructor = lookupConstructor(
                 "org.springframework.orm.hibernate4.SpringSessionSynchronization", SessionHolder.class, SessionFactory.class);
+        }catch(Exception e){
+            springSessionSynchronizationConstructor = lookupConstructor(
+                "org.springframework.orm.hibernate4.SpringSessionSynchronization", SessionHolder.class, SessionFactory.class, int.class);
+        }
     }
 
     protected Constructor<?> lookupConstructor(String className, Class<?>... argTypes) {
@@ -259,7 +264,11 @@ public class GrailsSessionContext implements CurrentSessionContext {
     }
 
     protected TransactionSynchronization createSpringSessionSynchronization(SessionHolder sessionHolder) {
-        return (TransactionSynchronization)create(springSessionSynchronizationConstructor, sessionHolder, sessionFactory);
+        if(springSessionSynchronizationConstructor.getTypeParameters().length==3){
+            return (TransactionSynchronization)create(springSessionSynchronizationConstructor, sessionHolder, sessionFactory);
+        }else{
+            return (TransactionSynchronization)create(springSessionSynchronizationConstructor, sessionHolder, sessionFactory, true);
+        }
     }
 
     protected Object create(Constructor<?> constructor, Object... args) {


### PR DESCRIPTION
In Spring 4.1.0.RC2, the SpringSessionSynchronization constructor changed. See https://jira.spring.io/browse/SPR-9020

This commit ensures compatibility with Spring before 4.1.0.RC2 and after 4.1.0.RC2.
