### PR TITLE
Retrieving meta method with getMetaMethod()

### DIFF
--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/support/EventTriggerCaller.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/support/EventTriggerCaller.java
@@ -51,13 +51,7 @@ public abstract class EventTriggerCaller {
     }
 
     private static EventTriggerCaller resolveMetaMethodCaller(String eventMethodName, MetaClass metaClass) {
-        MetaMethod metaMethod = null;
-        for(MetaMethod mm : metaClass.getMetaMethods()) {
-            if(eventMethodName.equals(mm.getName())) {
-                metaMethod = mm;
-                break;
-            }
-        }
+        MetaMethod metaMethod = metaClass.getMetaMethod(eventMethodName, EMPTY_ARRAY);
         if (metaMethod != null) {
             return new MetaMethodCaller(metaMethod);
         }


### PR DESCRIPTION
Fix for https://jira.grails.org/browse/GRAILS-11731 possibly related to strange Groovy's behavior described here: http://stackoverflow.com/questions/25895638/expandometaclass-metamethods-doesnt-return-added-methods

Tested with Grails 2.4.3.
