### PR TITLE
Work with SpringSessionSynchronization changes from Spring 4.1.0.RC2

### DIFF
--- a/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/GrailsSessionContext.java
+++ b/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/GrailsSessionContext.java
@@ -231,8 +231,13 @@ public class GrailsSessionContext implements CurrentSessionContext {
     protected void lookupConstructors() {
         springFlushSynchronizationConstructor = lookupConstructor(
                 "org.springframework.orm.hibernate4.SpringFlushSynchronization", Session.class);
-        springSessionSynchronizationConstructor = lookupConstructor(
+        try{
+            springSessionSynchronizationConstructor = lookupConstructor(
                 "org.springframework.orm.hibernate4.SpringSessionSynchronization", SessionHolder.class, SessionFactory.class);
+        }catch(Exception e){
+            springSessionSynchronizationConstructor = lookupConstructor(
+                "org.springframework.orm.hibernate4.SpringSessionSynchronization", SessionHolder.class, SessionFactory.class, boolean.class);
+        }
     }
 
     protected Constructor<?> lookupConstructor(String className, Class<?>... argTypes) {
@@ -259,7 +264,11 @@ public class GrailsSessionContext implements CurrentSessionContext {
     }
 
     protected TransactionSynchronization createSpringSessionSynchronization(SessionHolder sessionHolder) {
-        return (TransactionSynchronization)create(springSessionSynchronizationConstructor, sessionHolder, sessionFactory);
+        if(springSessionSynchronizationConstructor.getTypeParameters().length==2){
+            return (TransactionSynchronization)create(springSessionSynchronizationConstructor, sessionHolder, sessionFactory);
+        }else{
+            return (TransactionSynchronization)create(springSessionSynchronizationConstructor, sessionHolder, sessionFactory, false);
+        }
     }
 
     protected Object create(Constructor<?> constructor, Object... args) {


### PR DESCRIPTION
In Spring 4.1.0.RC2, the SpringSessionSynchronization constructor changed. See https://jira.spring.io/browse/SPR-9020

This commit ensures compatibility with Spring before 4.1.0.RC2 and after 4.1.0.RC2.

The signature change to the SpringSessionSynchronization constructor was the addition of a new "bool" parameter named "newSession". Here's the commit in Spring: spring-projects/spring-framework@5cbb1fc#diff-4340a4820b773949b5258699f411324f
I'm not positive I got the logic right in my commit. I'm hoping one of you folks who knows more about this part of the Grails code can tell if the logic is right around "newSession" - I set it true always in this commit, but I don't know if that's correct.
