### PR TITLE
GRAILS-11904 Support for ids of type java.util.UUID in grails-datastore-simple

### DIFF
--- a/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/UUIDTypeIdentifierSpec.groovy
+++ b/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/UUIDTypeIdentifierSpec.groovy
@@ -1,0 +1,42 @@
+package org.grails.datastore.gorm
+
+import grails.gorm.tests.GormDatastoreSpec
+import grails.persistence.Entity
+
+class UUIDTypeIdentifierSpec extends GormDatastoreSpec {
+
+  void "Test that an id with type of java.util.UUID is correctly generated"() {
+    when:"A domain with a UUID is saved"
+      def dm = new SimpleUUIDModel(name: "My Doc").save()
+
+    then:"The UUID is correctly generated"
+      dm != null
+      dm.id != null
+      SimpleUUIDModel.count() == 1
+
+    when:"Another entity is saved"
+      new SimpleUUIDModel(name: "Another").save()
+    then:"There are 2"
+      SimpleUUIDModel.count() == 2
+  }
+
+  @Override
+  List getDomainClasses() {
+    [SimpleUUIDModel]
+  }
+}
+
+@Entity
+class SimpleUUIDModel  {
+
+  UUID id
+  String name
+
+  static mapping = {
+    id generator:'uuid'
+  }
+
+  static constraints = {
+    name blank: false
+  }
+}

--- a/grails-datastore-simple/src/main/groovy/org/grails/datastore/mapping/simple/engine/SimpleMapEntityPersister.groovy
+++ b/grails-datastore-simple/src/main/groovy/org/grails/datastore/mapping/simple/engine/SimpleMapEntityPersister.groovy
@@ -14,6 +14,8 @@
  */
 package org.grails.datastore.mapping.simple.engine
 
+import java.util.UUID
+
 import org.grails.datastore.mapping.config.Property
 import org.grails.datastore.mapping.core.IdentityGenerationException
 import org.grails.datastore.mapping.core.OptimisticLockingException
@@ -257,6 +259,9 @@ class SimpleMapEntityPersister extends AbstractKeyValueEntityPersister<Map, Obje
                 key = session.getPersister(root).lastKey
             }
             return type == String ? key.toString() : key
+        }
+        else if (UUID.isAssignableFrom(type)) {
+          return UUID.randomUUID()
         }
         else {
             try {

--- a/grails-datastore-simple/src/main/groovy/org/grails/datastore/mapping/simple/engine/SimpleMapEntityPersister.groovy
+++ b/grails-datastore-simple/src/main/groovy/org/grails/datastore/mapping/simple/engine/SimpleMapEntityPersister.groovy
@@ -14,8 +14,6 @@
  */
 package org.grails.datastore.mapping.simple.engine
 
-import java.util.UUID
-
 import org.grails.datastore.mapping.config.Property
 import org.grails.datastore.mapping.core.IdentityGenerationException
 import org.grails.datastore.mapping.core.OptimisticLockingException


### PR DESCRIPTION
This is needed for handling mocked domain classes with UUID typed ids.