### PR TITLE
Spring 4.1 Compatibility: Ensure that org.springframework.http.converter.json.MappingJacksonHttpMessageConverter is present before attempting to use

### DIFF
--- a/grails-datastore-rest-client/src/main/groovy/grails/plugins/rest/client/RestBuilder.groovy
+++ b/grails-datastore-rest-client/src/main/groovy/grails/plugins/rest/client/RestBuilder.groovy
@@ -284,13 +284,17 @@ class RestBuilder {
         if(stringConverter) {
             messageConverters.remove(stringConverter)
         }
-        final mappingJackson2HttpMessageConverter = messageConverters.find { HttpMessageConverter httpMessageConverter -> httpMessageConverter instanceof MappingJackson2HttpMessageConverter }
-        if(mappingJackson2HttpMessageConverter) {
-            messageConverters.remove(mappingJackson2HttpMessageConverter)
+        if(ClassUtils.isPresent("org.springframework.http.converter.json.MappingJackson2HttpMessageConverter", getClass().getClassLoader())) {
+            final mappingJackson2HttpMessageConverter = messageConverters.find { HttpMessageConverter httpMessageConverter -> httpMessageConverter instanceof MappingJackson2HttpMessageConverter }
+            if(mappingJackson2HttpMessageConverter) {
+                messageConverters.remove(mappingJackson2HttpMessageConverter)
+            }
         }
-        final mappingJacksonHttpMessageConverter = messageConverters.find { HttpMessageConverter httpMessageConverter -> httpMessageConverter instanceof MappingJacksonHttpMessageConverter }
-        if(mappingJacksonHttpMessageConverter) {
-            messageConverters.remove(mappingJacksonHttpMessageConverter)
+        if(ClassUtils.isPresent("org.springframework.http.converter.json.MappingJacksonHttpMessageConverter", getClass().getClassLoader())) {
+            final mappingJacksonHttpMessageConverter = messageConverters.find { HttpMessageConverter httpMessageConverter -> httpMessageConverter instanceof MappingJacksonHttpMessageConverter }
+            if(mappingJacksonHttpMessageConverter) {
+                messageConverters.remove(mappingJacksonHttpMessageConverter)
+            }
         }
         if(ClassUtils.isPresent("com.google.gson.Gson", getClass().getClassLoader())) {
             messageConverters.add(new GsonHttpMessageConverter())


### PR DESCRIPTION
Spring 4.1 dropped org.springframework.http.converter.json.MappingJacksonHttpMessageConverter, so without this check, an error occurs

I also added the same guard around  org.springframework.http.converter.json.MappingJackson2HttpMessageConverter just to be safe :-)

See https://jira.grails.org/browse/GRAILS-11791

Thanks @jeffbrown for noticing this problem