### PR TITLE
Fix dataSource config prefix for Multiple Datasources

### DIFF
--- a/grails-datastore-gorm-hibernate/src/main/groovy/grails/orm/bootstrap/HibernateDatastoreSpringInitializer.groovy
+++ b/grails-datastore-gorm-hibernate/src/main/groovy/grails/orm/bootstrap/HibernateDatastoreSpringInitializer.groovy
@@ -124,7 +124,9 @@ class HibernateDatastoreSpringInitializer extends AbstractDatastoreInitializer {
                 String suffix = isDefault ? '' : '_' + dataSourceName
                 String prefix = isDefault ? '' : dataSourceName + '_'
                 def sessionFactoryName = isDefault ? defaultSessionFactoryBeanName : "sessionFactory$suffix"
+
                 def hibConfig = config.getProperty("hibernate$suffix", Map, Collections.emptyMap())
+                def dsConfigPrefix = config.containsProperty('dataSources') ? "dataSources.${isDefault ? 'dataSource' : dataSourceName}" : 'dataSource'
                 def ddlAutoSetting = config.getProperty("${dsConfigPrefix}.dbCreate", ddlAuto)
 
                 // default interceptor, can be overridden for extensibility

--- a/grails-datastore-gorm-hibernate4/src/main/groovy/grails/orm/bootstrap/HibernateDatastoreSpringInitializer.groovy
+++ b/grails-datastore-gorm-hibernate4/src/main/groovy/grails/orm/bootstrap/HibernateDatastoreSpringInitializer.groovy
@@ -130,7 +130,7 @@ class HibernateDatastoreSpringInitializer extends AbstractDatastoreInitializer {
                 def sessionFactoryName = isDefault ? defaultSessionFactoryBeanName : "sessionFactory$suffix"
 
                 def hibConfig = config.getProperty("hibernate$suffix", Map, Collections.emptyMap())
-                def dsConfigPrefix = isDefault ? "dataSource" :"dataSources.$dataSourceName"
+                def dsConfigPrefix = config.containsProperty('dataSources') ? "dataSources.${isDefault ? 'dataSource' : dataSourceName}" : 'dataSource'
                 def ddlAutoSetting = config.getProperty("${dsConfigPrefix}.dbCreate", ddlAuto)
 
                 // default interceptor, can be overridden for extensibility


### PR DESCRIPTION
fixes a problem that dbCreate/logSql/formatSql are not loaded for Multiple DataSource

related issue: https://jira.grails.org/browse/GRAILS-12037