### PR TITLE
Fixed bugs regarding Hibernate mapping and Gorm instance API

### DIFF
--- a/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/AbstractHibernateGormInstanceApi.groovy
+++ b/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/AbstractHibernateGormInstanceApi.groovy
@@ -235,6 +235,7 @@ abstract class AbstractHibernateGormInstanceApi<D> extends GormInstanceApi<D> {
     @Override
     D lock(D instance) {
         hibernateTemplate.lock(instance, LockMode.PESSIMISTIC_WRITE)
+        instance
     }
 
     @Override
@@ -266,7 +267,7 @@ abstract class AbstractHibernateGormInstanceApi<D> extends GormInstanceApi<D> {
             if (flush) {
                 flushSession session
             }
-            return merged
+            return (D)merged
         }
     }
 
@@ -346,7 +347,7 @@ abstract class AbstractHibernateGormInstanceApi<D> extends GormInstanceApi<D> {
             return false
         }
 
-        if (arguments.containsKey(ARGUMENT_VALIDATE)) {
+        if (arguments?.containsKey(ARGUMENT_VALIDATE)) {
             return GrailsClassUtils.getBooleanFromMap(ARGUMENT_VALIDATE, arguments)
         }
         return true

--- a/grails-datastore-gorm-hibernate/src/main/groovy/org/grails/orm/hibernate/HibernateGormInstanceApi.groovy
+++ b/grails-datastore-gorm-hibernate/src/main/groovy/org/grails/orm/hibernate/HibernateGormInstanceApi.groovy
@@ -43,7 +43,7 @@ class HibernateGormInstanceApi<D> extends AbstractHibernateGormInstanceApi<D> {
         def grailsApplication = datastore.getGrailsApplication()
         if (grailsApplication) {
             GrailsDomainClass domainClass = (GrailsDomainClass)grailsApplication.getArtefact(DomainClassArtefactHandler.TYPE, persistentClass.name)
-            config = (Map)grailsApplication.getFlatConfig().get('grails.gorm')
+            config = (Map)grailsApplication.getConfig().getProperty('grails.gorm',Map)
             hibernateTemplate = new GrailsHibernateTemplate(sessionFactory, grailsApplication, datastore.getDefaultFlushMode())
         }
         else {

--- a/grails-datastore-gorm-hibernate4/src/main/groovy/org/grails/orm/hibernate/HibernateGormInstanceApi.groovy
+++ b/grails-datastore-gorm-hibernate4/src/main/groovy/org/grails/orm/hibernate/HibernateGormInstanceApi.groovy
@@ -41,7 +41,7 @@ class HibernateGormInstanceApi<D> extends AbstractHibernateGormInstanceApi<D> {
         def grailsApplication = datastore.getGrailsApplication()
         if (grailsApplication) {
             GrailsDomainClass domainClass = (GrailsDomainClass)grailsApplication.getArtefact(DomainClassArtefactHandler.TYPE, persistentClass.name)
-            config = (Map)grailsApplication.getFlatConfig().get('grails.gorm')
+            config = (Map)grailsApplication.getConfig().getProperty('grails.gorm',Map)
             hibernateTemplate = new GrailsHibernateTemplate(sessionFactory, grailsApplication, datastore.getDefaultFlushMode())
         }
         else {

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/config/GrailsDomainClassMappingContext.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/config/GrailsDomainClassMappingContext.java
@@ -63,6 +63,8 @@ public class GrailsDomainClassMappingContext extends AbstractMappingContext {
     @Override
     protected PersistentEntity createPersistentEntity(Class javaClass) {
         GrailsDomainClass domainClass = (GrailsDomainClass) grailsApplication.getArtefact(DomainClassArtefactHandler.TYPE, javaClass.getName());
+        if (domainClass == null)
+            return null;
         return new GrailsDomainClassPersistentEntity(domainClass, this);
     }
 }


### PR DESCRIPTION
* External mapping of Hibernate domain classes via JPA annotations creates problems because of GormEntity trait not being injected. This throws NullPointerException when entity is saved without arguments. 

```
Person p = new Person()
p.save()
````
* When @ElementCollection annotation is used, referenced entity type is generally a Collection which is not a PersistentEntity. Fixed it by null checking.

* grails.gorm.failOnError was not working in HibernateGormInstanceApi ( in Grails 3 app ) because of getFlatConfig() method. 

