### PR TITLE
Retrieving meta method with getMetaMethod()

### DIFF
--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/support/EventTriggerCaller.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/support/EventTriggerCaller.java
@@ -51,13 +51,7 @@ public abstract class EventTriggerCaller {
     }
 
     private static EventTriggerCaller resolveMetaMethodCaller(String eventMethodName, MetaClass metaClass) {
-        MetaMethod metaMethod = null;
-        for(MetaMethod mm : metaClass.getMetaMethods()) {
-            if(eventMethodName.equals(mm.getName())) {
-                metaMethod = mm;
-                break;
-            }
-        }
+        MetaMethod metaMethod = metaClass.getMetaMethod(eventMethodName, EMPTY_ARRAY);
         if (metaMethod != null) {
             return new MetaMethodCaller(metaMethod);
         }


### PR DESCRIPTION
I cherry picked fix for https://jira.grails.org/browse/GRAILS-11731 that was not merged into 3.x. GRAILS-11731 causes error in grails-datastore-gorm 3.1.4 version which is used by hibernate plugins for Grails 2.x versions (including 2.5.0). It would be nice if new grails-datastore-gorm was released with this pull request merged. GRAILS-11731 is blocking us with Grails upgrade from 2.3.0 to 2.5.0.