### PR TITLE
Remove org.springframework.http.converter.json.GsonHttpMessageConverter.

### DIFF
--- a/grails-datastore-rest-client/src/main/groovy/grails/plugins/rest/client/RestBuilder.groovy
+++ b/grails-datastore-rest-client/src/main/groovy/grails/plugins/rest/client/RestBuilder.groovy
@@ -288,6 +288,9 @@ class RestBuilder {
         if(ClassUtils.isPresent("org.springframework.http.converter.json.MappingJacksonHttpMessageConverter", getClass().getClassLoader())) {
             messageConverters.removeAll { HttpMessageConverter httpMessageConverter -> httpMessageConverter.getClass().name == "org.springframework.http.converter.json.MappingJacksonHttpMessageConverter"}
         }
+        if(ClassUtils.isPresent("org.springframework.http.converter.json.GsonHttpMessageConverter", getClass().getClassLoader())) {
+            messageConverters.removeAll { HttpMessageConverter httpMessageConverter -> httpMessageConverter.getClass().name == "org.springframework.http.converter.json.GsonHttpMessageConverter"}
+        }
         if(ClassUtils.isPresent("com.google.gson.Gson", getClass().getClassLoader())) {
             messageConverters.add(new GsonHttpMessageConverter())
         }


### PR DESCRIPTION
The Spring implementation conflicts with the existing Grails
GsonHttpMessageConverter.  This became a problem in Grails 2.5.x.