### PR TITLE
Avoid composite unique constraint name clashes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ apply from: "gradle/idea.gradle"
 subprojects {
     configurations {
         documentation
-    }    
+    }
    version = "${projectVersion}.${releaseType}"
    group = "org.grails"
 
@@ -345,6 +345,9 @@ subprojects {
                     // If there is a corresponding source file in the particular modules
                     // test source tree. Allows a module to override a test/helper.
 
+                    if (!details.file.isFile()) {
+                        return false
+                    }
                     def candidatePath = details.file.absolutePath
                     def relativePath = toBaseClassRelativePathWithoutExtension(tckClassesDir.absolutePath, candidatePath)
 
@@ -369,7 +372,7 @@ subprojects {
 
         configure([groovydoc]) {
             groovyClasspath += configurations.documentation
-        }        
+        }
 
         modifyPom {
             delegate.project {

--- a/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/cfg/AbstractGrailsDomainBinder.java
+++ b/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/cfg/AbstractGrailsDomainBinder.java
@@ -2861,7 +2861,7 @@ public abstract class AbstractGrailsDomainBinder {
 
     protected void createUniqueKeyForColumns(Table table, String columnName, List<Column> keyList) {
         Collections.reverse(keyList);
-        UniqueKey key = table.getOrCreateUniqueKey("unique_" + columnName);
+        UniqueKey key = table.getOrCreateUniqueKey("unique_" + table.getName() + "_" + columnName);
         List<?> columns = key.getColumns();
         if (columns.isEmpty()) {
             LOG.debug("create unique key for " + table.getName() + " columns = " + keyList);

--- a/grails-datastore-gorm-hibernate/src/test/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinderTests.groovy
+++ b/grails-datastore-gorm-hibernate/src/test/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinderTests.groovy
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package org.grails.orm.hibernate.cfg
+
 import grails.core.DefaultGrailsApplication
 import grails.core.GrailsDomainClass
 import grails.util.Holders
@@ -305,6 +306,38 @@ class Widget {
         Column descriptionColumn = tableMapping.getColumn(new Column("description"))
         assertTrue nameColumn.isUnique()
         assertFalse descriptionColumn.isUnique()
+    }
+
+    void testGroupUniqueProperty() {
+        DefaultGrailsDomainConfiguration config = getDomainConfig('''
+class CompositeUnique1 {
+    Long id
+    Long version
+    String name
+    String surname
+    static constraints = {
+        name unique:'surname'
+    }
+}
+class CompositeUnique2 {
+    Long id
+    Long version
+    String name
+    String surname
+    static constraints = {
+        name unique:'surname'
+    }
+}
+''')
+        Table tableMapping = getTableMapping("composite_unique1", config)
+        UniqueKey key = tableMapping.getUniqueKey('unique_composite_unique1_name')
+        assertNotNull(key)
+
+        Table tableMapping2 = getTableMapping("composite_unique2", config)
+        UniqueKey key2 = tableMapping2.getUniqueKey('unique_composite_unique2_name')
+        assertNotNull(key2)
+
+        assertTrue(key.name != key2.name)
     }
 
     void testPrecisionProperty() {
@@ -1123,7 +1156,7 @@ class CascadeParent {
     }
 }"""))
         grailsDomainBinder.evaluateMapping(cascadeParent)
-        return (PropertyConfig)cascadeParent.persistentProperties.find { it.name == 'child' }.mapping.mappedForm
+        return (PropertyConfig) cascadeParent.persistentProperties.find { it.name == 'child' }.mapping.mappedForm
     }
 
     private org.hibernate.mapping.Collection findCollection(DefaultGrailsDomainConfiguration config, String role) {
@@ -1178,13 +1211,13 @@ class CascadeParent {
 
     private void assertColumnNotNullable(String tablename, String columnName, DefaultGrailsDomainConfiguration config) {
         Table table = getTableMapping(tablename, config)
-        assertFalse(table.name + "." + columnName +  " is nullable",
+        assertFalse(table.name + "." + columnName + " is nullable",
                 table.getColumn(new Column(columnName)).isNullable())
     }
 
     private void assertColumnNullable(String tablename, String columnName, DefaultGrailsDomainConfiguration config) {
         Table table = getTableMapping(tablename, config)
-        assertTrue(table.name + "." + columnName +  " is not nullable",
+        assertTrue(table.name + "." + columnName + " is not nullable",
                 table.getColumn(new Column(columnName)).isNullable())
     }
 

--- a/grails-datastore-gorm-hibernate4/src/test/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinderTests.groovy
+++ b/grails-datastore-gorm-hibernate4/src/test/groovy/org/grails/orm/hibernate/cfg/GrailsDomainBinderTests.groovy
@@ -31,6 +31,7 @@ import org.hibernate.mapping.PersistentClass
 import org.hibernate.mapping.Property
 import org.hibernate.mapping.SimpleValue
 import org.hibernate.mapping.Table
+import org.hibernate.mapping.UniqueKey
 import org.springframework.context.support.GenericApplicationContext
 
 /**
@@ -312,6 +313,39 @@ class Widget {
 		assertTrue nameColumn.isUnique()
 		assertFalse descriptionColumn.isUnique()
 	}
+
+	void testGroupUniqueProperty() {
+		DefaultGrailsDomainConfiguration config = getDomainConfig('''
+class CompositeUnique1 {
+    Long id
+    Long version
+    String name
+    String surname
+    static constraints = {
+        name unique:'surname'
+    }
+}
+class CompositeUnique2 {
+    Long id
+    Long version
+    String name
+    String surname
+    static constraints = {
+        name unique:'surname'
+    }
+}
+''')
+		Table tableMapping = getTableMapping("composite_unique1", config)
+		UniqueKey key = tableMapping.getUniqueKey('unique_composite_unique1_name')
+		assertNotNull(key)
+
+		Table tableMapping2 = getTableMapping("composite_unique2", config)
+		UniqueKey key2 = tableMapping2.getUniqueKey('unique_composite_unique2_name')
+		assertNotNull(key2)
+
+		assertTrue(key.name != key2.name)
+	}
+
 
 	void testPrecisionProperty() {
 		DefaultGrailsDomainConfiguration config = getDomainConfig('''


### PR DESCRIPTION
I recently came accross https://jira.grails.org/browse/GRAILS-11600 in Grails 2.5.3. 

The fix adds the table name into the unique constraint name to avoid name clashes between composite constraints from different tables.
Also, I had to change the build script a little bit. I'm working on Windows and it seems that the relative path holds a drive letter and gradle seems not to be able to cope with that. So I purged all attempts of folders beforehand.