### PR TITLE
Hibernate - Fix datasource namespaces when using 'ALL' datasources

### DIFF
--- a/grails-datastore-gorm-hibernate/src/main/groovy/org/grails/orm/hibernate/HibernateGormEnhancer.groovy
+++ b/grails-datastore-gorm-hibernate/src/main/groovy/org/grails/orm/hibernate/HibernateGormEnhancer.groovy
@@ -24,6 +24,7 @@ import org.grails.datastore.mapping.core.Datastore
 import org.grails.datastore.mapping.model.PersistentEntity
 import org.grails.orm.hibernate.cfg.GrailsHibernateUtil
 import org.grails.orm.hibernate.cfg.HibernateUtils
+import org.grails.orm.hibernate.cfg.Mapping
 import org.springframework.transaction.PlatformTransactionManager
 
 /**
@@ -77,7 +78,7 @@ class HibernateGormEnhancer extends GormEnhancer {
         if(datastoreStoreDataSourceName.equals(dataSourceName) ) {
             qualifiers.add(Entity.DEFAULT_DATA_SOURCE)
         }
-        if(allMappedDataSources.contains(datastoreStoreDataSourceName)) {
+        if(allMappedDataSources.contains(datastoreStoreDataSourceName) || allMappedDataSources.contains(Mapping.ALL_DATA_SOURCES)) {
             qualifiers.add(datastoreStoreDataSourceName)
         }
         return qualifiers

--- a/grails-datastore-gorm-hibernate/src/test/groovy/grails/orm/bootstrap/HibernateDatastoreSpringInitializerSpec.groovy
+++ b/grails-datastore-gorm-hibernate/src/test/groovy/grails/orm/bootstrap/HibernateDatastoreSpringInitializerSpec.groovy
@@ -102,7 +102,7 @@ class HibernateDatastoreSpringInitializerSpec extends Specification{
     void "Test configure multiple data sources"() {
         given:"An initializer instance"
 
-        def datastoreInitializer = new HibernateDatastoreSpringInitializer(Person, Book)
+        def datastoreInitializer = new HibernateDatastoreSpringInitializer(Person, Book, Author)
         def dataSource = new DriverManagerDataSource("jdbc:h2:mem:people;MVCC=TRUE;LOCK_TIMEOUT=10000;DB_CLOSE_DELAY=-1", 'sa', '')
         dataSource.driverClassName = Driver.name
 
@@ -115,7 +115,7 @@ class HibernateDatastoreSpringInitializerSpec extends Specification{
         when:"the application is configured"
         datastoreInitializer.configureForDataSources(dataSource: dataSource, books:booksDs, moreBooks:moreBooksDs)
 
-        then:"Each domain has a separate data source"
+        then:"Each domain has the correct data source(s)"
         Person.count() == 0
         Person.withSession { Session s ->
             assert s.connection().metaData.getURL() == "jdbc:h2:mem:people"
@@ -133,6 +133,19 @@ class HibernateDatastoreSpringInitializerSpec extends Specification{
         }
         Book.moreBooks.count() == 0
         Book.moreBooks.withNewSession { Session s ->
+            assert s.connection().metaData.getURL() == "jdbc:h2:mem:moreBooks"
+            return true
+        }
+        Author.withNewSession { Author.count() == 0 }
+        Author.withNewSession { Session s ->
+            assert s.connection().metaData.getURL() == "jdbc:h2:mem:people"
+            return true
+        }
+        Author.books.withNewSession { Session s ->
+            assert s.connection().metaData.getURL() == "jdbc:h2:mem:books"
+            return true
+        }
+        Author.moreBooks.withNewSession { Session s ->
             assert s.connection().metaData.getURL() == "jdbc:h2:mem:moreBooks"
             return true
         }
@@ -194,6 +207,20 @@ class Book {
 
     static mapping = {
         datasources( ['books', 'moreBooks'] )
+    }
+    static constraints = {
+        name blank:false
+    }
+}
+
+@Entity
+class Author {
+    Long id
+    Long version
+    String name
+
+    static mapping = {
+        datasource 'ALL'
     }
     static constraints = {
         name blank:false

--- a/grails-datastore-gorm-hibernate4/src/main/groovy/org/grails/orm/hibernate/HibernateGormEnhancer.groovy
+++ b/grails-datastore-gorm-hibernate4/src/main/groovy/org/grails/orm/hibernate/HibernateGormEnhancer.groovy
@@ -58,7 +58,7 @@ class HibernateGormEnhancer extends GormEnhancer {
         if(datastoreStoreDataSourceName.equals(dataSourceName) ) {
             qualifiers.add(Entity.DEFAULT_DATA_SOURCE)
         }
-        if(allMappedDataSources.contains(datastoreStoreDataSourceName)) {
+        if(allMappedDataSources.contains(datastoreStoreDataSourceName) || allMappedDataSources.contains(Mapping.ALL_DATA_SOURCES)) {
             qualifiers.add(datastoreStoreDataSourceName)
         }
         return qualifiers

--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/HibernateGormEnhancer.groovy
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/HibernateGormEnhancer.groovy
@@ -58,7 +58,7 @@ class HibernateGormEnhancer extends GormEnhancer {
         if(datastoreStoreDataSourceName.equals(dataSourceName) ) {
             qualifiers.add(Entity.DEFAULT_DATA_SOURCE)
         }
-        if(allMappedDataSources.contains(datastoreStoreDataSourceName)) {
+        if(allMappedDataSources.contains(datastoreStoreDataSourceName) || allMappedDataSources.contains(Mapping.ALL_DATA_SOURCES)) {
             qualifiers.add(datastoreStoreDataSourceName)
         }
         return qualifiers


### PR DESCRIPTION
A qualifier should be added for a given datasource whether an entity
explicitly maps that datasource, or if it maps all datasources. If this
doesn't happen, namespaces for each datasource won't be configured.