### PR TITLE
Fix https://github.com/grails/grails-core/issues/9619

### DIFF
--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormValidationApi.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormValidationApi.groovy
@@ -75,16 +75,6 @@ class GormValidationApi<D> extends AbstractGormApi<D> {
 
         Errors errors = getErrors(instance)
 
-        if (validator instanceof CascadingValidator) {
-            validator.validate instance, localErrors, arguments?.deepValidate != false
-        } else {
-            validator.validate instance, localErrors
-        }
-
-        if (fields) {
-            localErrors = filterErrors(localErrors, fields as Set, instance)
-        }
-
         for (error in errors.allErrors) {
             if (error instanceof FieldError) {
                 if (((FieldError)error).bindingFailure) {
@@ -93,6 +83,16 @@ class GormValidationApi<D> extends AbstractGormApi<D> {
             } else {
                 localErrors.addError error
             }
+        }
+
+        if (validator instanceof CascadingValidator) {
+            validator.validate instance, localErrors, arguments?.deepValidate != false
+        } else {
+            validator.validate instance, localErrors
+        }
+
+        if (fields) {
+            localErrors = filterErrors(localErrors, fields as Set, instance)
         }
 
         setErrors(instance, localErrors)


### PR DESCRIPTION
All tests in both grails-core and grails-datastore-gorm are passed with this patch except a just single test case which has a wrong expected value depending on the issue.

See the issue of "validation is executed for mocked domain class which has typeMismatch error in unit test" (https://github.com/grails/grails-core/issues/9619).