### PR TITLE
Tests for issue #641 - unique index is duplicated for association index

### DIFF
--- a/grails-datastore-gorm-hibernate/src/test/groovy/grails/gorm/tests/MultiColumnUniqueConstraintSpec.groovy
+++ b/grails-datastore-gorm-hibernate/src/test/groovy/grails/gorm/tests/MultiColumnUniqueConstraintSpec.groovy
@@ -51,9 +51,30 @@ class MultiColumnUniqueConstraintSpec extends GormSpec {
         then:
         thrown DataIntegrityViolationException
     }
+
+    void "test generated unique constraints for related domains"() {
+        given: 'two existing tasks'
+            Task task1 = new Task(name: 'task1').save(flush: true, failOnError: true)
+            Task task2 = new Task(name: 'task2').save(flush: true, failOnError: true)
+
+        when: 'saving task links for the same toTask but not breaking unique index'
+            TaskLink taskLink1 = new TaskLink(fromTask: task1, toTask: task2).save(flush: true, validate: false)
+            TaskLink taskLink2 = new TaskLink(fromTask: task2, toTask: task2).save(flush: true, validate: false)
+
+        then: 'both links may be saved'
+            taskLink1 
+            taskLink2
+
+        when: 'instance which breaks unique index is saved'
+            new TaskLink(fromTask: task1, toTask: task2).save(flush: true, validate: false)            
+
+        then: 'DataIntegrityViolationException is thrown'
+            thrown DataIntegrityViolationException
+    }
+
     @Override
     List getDomainClasses() {
-        [DomainOne, DomainObject1, DomainObject2]
+        [DomainOne, DomainObject1, DomainObject2, Task, TaskLink]
     }
 }
 
@@ -86,5 +107,21 @@ class DomainObject2 {
 
     static constraints = {
         objectId(unique: ['someUniqueField'])
+    }
+}
+
+@Entity
+class Task {
+    String name
+}
+
+@Entity
+class TaskLink {
+
+    Task toTask
+    Task fromTask
+
+    static constraints = {
+        toTask unique: ['fromTask']
     }
 }

--- a/grails-datastore-gorm-hibernate5/src/test/groovy/grails/gorm/tests/MultiColumnUniqueConstraintSpec.groovy
+++ b/grails-datastore-gorm-hibernate5/src/test/groovy/grails/gorm/tests/MultiColumnUniqueConstraintSpec.groovy
@@ -22,9 +22,30 @@ class MultiColumnUniqueConstraintSpec extends GormDatastoreSpec {
         then:
         thrown DataIntegrityViolationException
     }
+
+    void "test generated unique constraints for related domains"() {
+        given: 'two existing tasks'
+            Task task1 = new Task(name: 'task1').save(flush: true, failOnError: true)
+            Task task2 = new Task(name: 'task2').save(flush: true, failOnError: true)
+
+        when: 'saving task links for the same toTask but not breaking unique index'
+            TaskLink taskLink1 = new TaskLink(fromTask: task1, toTask: task2).save(flush: true, validate: false)
+            TaskLink taskLink2 = new TaskLink(fromTask: task2, toTask: task2).save(flush: true, validate: false)
+
+        then: 'both links may be saved'
+            taskLink1 
+            taskLink2
+
+        when: 'instance which breaks unique index is saved'
+            new TaskLink(fromTask: task1, toTask: task2).save(flush: true, validate: false)            
+
+        then: 'DataIntegrityViolationException is thrown'
+            thrown DataIntegrityViolationException
+    }
+
     @Override
     List getDomainClasses() {
-        [DomainOne]
+        [DomainOne, Task, TaskLink]
     }
 }
 
@@ -36,5 +57,22 @@ class DomainOne {
 
     static constraints = {
         action unique: 'controller'
+    }
+}
+
+
+@Entity
+class Task {
+    String name
+}
+
+@Entity
+class TaskLink {
+
+    Task toTask
+    Task fromTask
+
+    static constraints = {
+        toTask unique: ['fromTask']
     }
 }


### PR DESCRIPTION
Both tests will currently fail because of the issue reported under #641 
I did some investigation and it seems that issue is fixed (and tests pass) when `AbstractGrailsDomainBinder` is modified in line 2320 from:
```
if (config != null) {
    c.setUnique(config.isUnique());
}
```
to 
```
if (config != null && !config.isUniqueWithinGroup()) {
    c.setUnique(config.isUnique());
}
```

possibly it should also be modified in next else/if to:
```
else if (property.isBidirectional() && isHasOne(property.getInverseSide()) && !config.isUniqueWithinGroup())
```

Such change may have big impact which I don't fully understand so I do not include those changes in PR.

For Hibernate5 the same changes fix the tests but in class `GrailsDomainBinder` lines 2267 and 2270

Changes are similar to fix for #617 but in association related part of binder