### PR TITLE
Handle multiple datasources mapping configuration

### DIFF
--- a/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/DefaultGrailsDomainConfiguration.java
+++ b/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/DefaultGrailsDomainConfiguration.java
@@ -95,7 +95,7 @@ public class DefaultGrailsDomainConfiguration extends Configuration implements G
             Thread.currentThread().setContextClassLoader(grailsApplication.getClassLoader());
         }
 
-        configureDomainBinder(grailsApplication, domainClasses);
+        configureDomainBinder(grailsApplication, domainClasses, this.dataSourceName);
 
         for (GrailsDomainClass domainClass : domainClasses) {
             if (!GrailsHibernateUtil.usesDatasource(domainClass, dataSourceName)) {
@@ -111,8 +111,11 @@ public class DefaultGrailsDomainConfiguration extends Configuration implements G
         configLocked = true;
     }
 
-    public static void configureDomainBinder(GrailsApplication grailsApplication, Set<GrailsDomainClass> domainClasses) {
-        Object defaultMapping = Eval.x(grailsApplication, "x.config?.grails?.gorm?.default?.mapping");
+    public static void configureDomainBinder(GrailsApplication grailsApplication, Set<GrailsDomainClass> domainClasses, String datasourceName) {
+        Object defaultMapping = Eval.x( grailsApplication, "x.config?.grails?.gorm?." + datasourceName + "?.mapping" );
+        if(defaultMapping == null || !(defaultMapping instanceof Closure)) {
+            defaultMapping = Eval.x( grailsApplication, "x.config?.grails?.gorm?.default?.mapping" );
+        }
         // do Grails class configuration
         for (GrailsDomainClass domainClass : domainClasses) {
             if (defaultMapping instanceof Closure) {
@@ -123,7 +126,7 @@ public class DefaultGrailsDomainConfiguration extends Configuration implements G
             }
         }
     }
-    
+
     @Override
     protected void reset() {
         super.reset();

--- a/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsAnnotationConfiguration.java
+++ b/grails-datastore-gorm-hibernate4/src/main/groovy/org/codehaus/groovy/grails/orm/hibernate/cfg/GrailsAnnotationConfiguration.java
@@ -80,9 +80,9 @@ public class GrailsAnnotationConfiguration extends Configuration implements Grai
     private static final String RESOURCE_PATTERN = "/**/*.class";
 
     private static final TypeFilter[] ENTITY_TYPE_FILTERS = new TypeFilter[] {
-          new AnnotationTypeFilter(Entity.class, false),
-          new AnnotationTypeFilter(Embeddable.class, false),
-          new AnnotationTypeFilter(MappedSuperclass.class, false)};
+            new AnnotationTypeFilter(Entity.class, false),
+            new AnnotationTypeFilter(Embeddable.class, false),
+            new AnnotationTypeFilter(MappedSuperclass.class, false)};
 
     private ResourcePatternResolver resourcePatternResolver;
     private ServiceRegistry serviceRegistry;
@@ -106,7 +106,7 @@ public class GrailsAnnotationConfiguration extends Configuration implements Grai
 
     private boolean shouldMapWithGorm(GrailsDomainClass domainClass) {
         return !AnnotationDomainClassArtefactHandler.isJPADomainClass(domainClass.getClazz()) &&
-               domainClass.getMappingStrategy().equalsIgnoreCase(GrailsDomainClass.GORM);
+                domainClass.getMappingStrategy().equalsIgnoreCase(GrailsDomainClass.GORM);
     }
 
     /* (non-Javadoc)
@@ -144,7 +144,7 @@ public class GrailsAnnotationConfiguration extends Configuration implements Grai
                 LOG.debug("[GrailsAnnotationConfiguration] ["+domainClasses.size()+"] Grails domain classes to bind to persistence runtime");
 
             // do Grails class configuration
-            DefaultGrailsDomainConfiguration.configureDomainBinder(grailsApplication, domainClasses);
+            DefaultGrailsDomainConfiguration.configureDomainBinder(grailsApplication, domainClasses, this.dataSourceName);
 
             for (GrailsDomainClass domainClass : domainClasses) {
 


### PR DESCRIPTION
Allows to define one mapping configuration by datasource. For example, it is possible to use generated id for one datasource and assigned id for one other.
