### PR TITLE
Pass the proper map containing ARGUMENT_MERGE in merge()

### DIFF
--- a/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/AbstractHibernateGormInstanceApi.groovy
+++ b/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/AbstractHibernateGormInstanceApi.groovy
@@ -164,7 +164,7 @@ abstract class AbstractHibernateGormInstanceApi<D> extends GormInstanceApi<D> {
     D merge(D instance, Map params) {
         Map args = new HashMap(params)
         args[ARGUMENT_MERGE] = true
-        return save(instance, params)
+        return save(instance, args)
     }
 
     @Override


### PR DESCRIPTION
In the AbstractHibernateGormInstanceApi.merge() method the params map is passed instead of the proper args map. This results in the Gorm's merge being the Hibernate's save instead of merge.

#676