### PR TITLE
Enable Gorm with JPA entities in Hibernate 5 plugin

### DIFF
--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/HibernateMappingContextSessionFactoryBean.java
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/HibernateMappingContextSessionFactoryBean.java
@@ -4,6 +4,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.grails.orm.hibernate.cfg.HibernateMappingContext;
 import org.grails.orm.hibernate.cfg.HibernateMappingContextConfiguration;
+import org.grails.orm.hibernate.cfg.HibernateMappingContextConfigurationBuilder;
 import org.grails.orm.hibernate.cfg.Mapping;
 import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
@@ -383,12 +384,7 @@ public class HibernateMappingContextSessionFactoryBean extends HibernateExceptio
 
         configuration = newConfiguration();
 
-        if(hibernateMappingContext == null) {
 
-            throw new IllegalArgumentException("HibernateMappingContext is required.");
-        }
-
-        configuration.setHibernateMappingContext(hibernateMappingContext);
 
         if (configLocations != null) {
             for (Resource resource : configLocations) {
@@ -462,9 +458,7 @@ public class HibernateMappingContextSessionFactoryBean extends HibernateExceptio
             configuration.scanPackages(packagesToScan);
         }
 
-        if (eventListeners != null) {
-            configuration.setEventListeners(eventListeners);
-        }
+
 
         sessionFactory = doBuildSessionFactory();
 
@@ -548,15 +542,34 @@ public class HibernateMappingContextSessionFactoryBean extends HibernateExceptio
         if (configClass == null) {
             configClass = HibernateMappingContextConfiguration.class;
         }
-        HibernateMappingContextConfiguration config = BeanUtils.instantiateClass(configClass);
+
+        HibernateMappingContextConfigurationBuilder config = new HibernateMappingContextConfigurationBuilder(configClass);
+
+        if(hibernateMappingContext == null) {
+
+            throw new IllegalArgumentException("HibernateMappingContext is required.");
+        }
+
+        config.setHibernateMappingContext(hibernateMappingContext);
+
+
+        //HibernateMappingContextConfiguration config = BeanUtils.instantiateClass(configClass);
         config.setDataSourceName(dataSourceName);
         config.setApplicationContext(applicationContext);
         config.setSessionFactoryBeanName(sessionFactoryBeanName);
         config.setHibernateEventListeners(hibernateEventListeners);
+
+        if (eventListeners != null) {
+            config.setEventListeners(eventListeners);
+        }
+
         if (currentSessionContextClass != null) {
             config.setProperty(Environment.CURRENT_SESSION_CONTEXT_CLASS, currentSessionContextClass.getName());
         }
-        return config;
+
+
+
+        return config.build();
     }
 
 //    protected void configureGrailsJdbcTransactionFactory(Configuration config) {

--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/boot/spi/GrailsMetadataBuilderInitializer.groovy
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/boot/spi/GrailsMetadataBuilderInitializer.groovy
@@ -1,0 +1,26 @@
+package org.grails.orm.hibernate.boot.spi
+
+
+import groovy.transform.CompileStatic
+import org.hibernate.annotations.common.reflection.MetadataProviderInjector
+import org.hibernate.boot.MetadataBuilder
+import org.hibernate.boot.internal.MetadataBuilderImpl
+import org.hibernate.boot.registry.StandardServiceRegistry
+import org.hibernate.boot.spi.MetadataBuilderInitializer
+
+@CompileStatic
+class GrailsMetadataBuilderInitializer implements MetadataBuilderInitializer
+{
+    @Override
+    void contribute(MetadataBuilder metadataBuilder, StandardServiceRegistry serviceRegistry)
+    {
+        def manager = new GroovyReflectionManager()
+        if (metadataBuilder instanceof MetadataBuilderImpl) {
+            def reflectionManager = (Object)((MetadataBuilderImpl)metadataBuilder).getMetadataBuildingOptions().getReflectionManager()
+            if (reflectionManager instanceof MetadataProviderInjector) {
+                manager.setMetadataProvider(((MetadataProviderInjector)reflectionManager).metadataProvider)
+                metadataBuilder.applyReflectionManager(manager)
+            }
+        }
+    }
+}

--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/boot/spi/GroovyReflectionManager.java
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/boot/spi/GroovyReflectionManager.java
@@ -1,0 +1,40 @@
+package org.grails.orm.hibernate.boot.spi;
+
+
+import org.hibernate.annotations.common.reflection.XClass;
+import org.hibernate.annotations.common.reflection.java.JavaReflectionManager;
+
+
+public class GroovyReflectionManager extends JavaReflectionManager
+{
+    @Override
+    public XClass toXClass(Class clazz)
+    {
+        XClass xClass = super.toXClass(clazz);
+        return new GroovyXClass(xClass);
+    }
+
+    @Override
+    public Class toClass(XClass xClass)
+    {
+        if (xClass instanceof GroovyXClass)
+            return ((GroovyXClass)xClass).toJavaClass();
+        return super.toClass(xClass);
+    }
+
+
+
+    public boolean equals(XClass class1, Class class2)
+    {
+        if (class1 == null)
+        {
+            return class2 == null;
+        }
+
+        if (class1 instanceof GroovyXClass)
+            return ((GroovyXClass)class1).toJavaClass().equals(class2);
+
+        return super.equals(class1,class2);
+    }
+
+}

--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/boot/spi/GroovyXClass.java
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/boot/spi/GroovyXClass.java
@@ -1,0 +1,156 @@
+package org.grails.orm.hibernate.boot.spi;
+
+import org.hibernate.annotations.common.reflection.Filter;
+import org.hibernate.annotations.common.reflection.XClass;
+import org.hibernate.annotations.common.reflection.XMethod;
+import org.hibernate.annotations.common.reflection.XProperty;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GroovyXClass implements XClass
+{
+    private XClass xClass;
+    private Class clazz;
+
+    public Class toClassWithReflection(XClass xClass) throws ClassNotFoundException
+    {
+
+        Class javaClass = Class.forName(xClass.getName());
+        return javaClass;
+    }
+
+
+    GroovyXClass(XClass xClass)
+    {
+        this.xClass = xClass;
+        try
+        {
+            this.clazz = toClassWithReflection(xClass);
+        } catch (ClassNotFoundException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public String getName()
+    {
+        return xClass.getName();
+    }
+
+    @Override
+    public XClass getSuperclass()
+    {
+        return xClass.getSuperclass();
+    }
+
+    @Override
+    public XClass[] getInterfaces()
+    {
+        return xClass.getInterfaces();
+    }
+
+    @Override
+    public boolean isInterface()
+    {
+        return xClass.isInterface();
+    }
+
+    @Override
+    public boolean isAbstract()
+    {
+        return xClass.isAbstract();
+    }
+
+    @Override
+    public boolean isPrimitive()
+    {
+        return xClass.isPrimitive();
+    }
+
+    @Override
+    public boolean isEnum()
+    {
+        return xClass.isEnum();
+    }
+
+    @Override
+    public boolean isAssignableFrom(XClass c)
+    {
+        return xClass.isAssignableFrom(c);
+    }
+
+    @Override
+    public List<XProperty> getDeclaredProperties(String accessType)
+    {
+        List<XProperty> results = new ArrayList();
+        for(XProperty property : xClass.getDeclaredProperties(accessType)) {
+            if (!ignoreXProperty(property))
+                results.add(property);
+        }
+
+        return results;
+    }
+
+    private boolean ignoreXProperty(XProperty property)
+    {
+        String name = property.getName();
+        if (name.contains("DirtyCheckable") || name.contains("GormValidateable"))
+            return true;
+        return false;
+    }
+
+    @Override
+    public List<XProperty> getDeclaredProperties(String accessType, Filter filter)
+    {
+        return xClass.getDeclaredProperties(accessType, filter);
+    }
+
+    @Override
+    public List<XMethod> getDeclaredMethods()
+    {
+        return xClass.getDeclaredMethods();
+    }
+
+    @Override
+    public <T extends Annotation> T getAnnotation(Class<T> annotationType)
+    {
+        return xClass.getAnnotation(annotationType);
+    }
+
+    @Override
+    public <T extends Annotation> boolean isAnnotationPresent(Class<T> annotationType)
+    {
+        return xClass.isAnnotationPresent(annotationType);
+    }
+
+    @Override
+    public Annotation[] getAnnotations()
+    {
+        return xClass.getAnnotations();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        GroovyXClass that = (GroovyXClass) o;
+
+        return xClass.equals(that.xClass);
+
+    }
+
+    Class toJavaClass() {
+        return this.clazz;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return xClass.hashCode();
+    }
+}

--- a/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/cfg/HibernateMappingContextConfigurationBuilder.java
+++ b/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/cfg/HibernateMappingContextConfigurationBuilder.java
@@ -1,0 +1,129 @@
+package org.grails.orm.hibernate.cfg;
+
+
+import org.grails.orm.hibernate.EventListenerIntegrator;
+import org.grails.orm.hibernate.GrailsSessionContext;
+import org.grails.orm.hibernate.HibernateEventListeners;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.BootstrapServiceRegistry;
+import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
+import org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl;
+import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
+import org.hibernate.boot.spi.MetadataContributor;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Environment;
+import org.hibernate.context.spi.CurrentSessionContext;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.support.ResourcePatternUtils;
+
+import java.util.*;
+
+public class HibernateMappingContextConfigurationBuilder
+{
+    private Class<? extends HibernateMappingContextConfiguration> configClass = HibernateMappingContextConfiguration.class;
+
+    protected String sessionFactoryBeanName = "sessionFactory";
+    protected String dataSourceName = Mapping.DEFAULT_DATA_SOURCE;
+    protected HibernateMappingContext hibernateMappingContext;
+    private Class<? extends CurrentSessionContext> currentSessionContext = GrailsSessionContext.class;
+    private HibernateEventListeners hibernateEventListeners;
+    private Map<String, Object> eventListeners;
+    private Properties properties = new Properties();
+
+
+    public HibernateMappingContextConfigurationBuilder(Class<? extends HibernateMappingContextConfiguration> configClass)
+    {
+        this.configClass = configClass;
+    }
+
+    public Properties getProperties()
+    {
+        return properties;
+    }
+
+    public void setProperty(String propertyName, String value) {
+        properties.setProperty( propertyName, value );
+    }
+
+    public void setHibernateMappingContext(HibernateMappingContext hibernateMappingContext) {
+        this.hibernateMappingContext = hibernateMappingContext;
+    }
+
+    public void setSessionFactoryBeanName(String name) {
+        sessionFactoryBeanName = name;
+    }
+
+    public void setDataSourceName(String name) {
+        dataSourceName = name;
+    }
+
+    /**
+     * Default listeners.
+     * @param listeners the listeners
+     */
+    public void setEventListeners(Map<String, Object> listeners) {
+        eventListeners = listeners;
+    }
+
+    /**
+     * User-specifiable extra listeners.
+     * @param listeners the listeners
+     */
+    public void setHibernateEventListeners(HibernateEventListeners listeners) {
+        hibernateEventListeners = listeners;
+    }
+
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException
+    {
+        String dsName = Mapping.DEFAULT_DATA_SOURCE.equals(dataSourceName) ? "dataSource" : "dataSource_" + dataSourceName;
+        getProperties().put(Environment.DATASOURCE, applicationContext.getBean(dsName));
+        getProperties().put(Environment.CURRENT_SESSION_CONTEXT_CLASS, currentSessionContext.getName());
+        getProperties().put(AvailableSettings.CLASSLOADERS, applicationContext.getClassLoader());
+    }
+
+    public HibernateMappingContextConfiguration build()
+    {
+
+        Collection<ClassLoader> appClassLoaders = HibernateMappingContextConfiguration.getAppClassLoaders(getProperties(),getClass());
+
+        final GrailsDomainBinder domainBinder = new GrailsDomainBinder(dataSourceName, sessionFactoryBeanName, hibernateMappingContext);
+
+        ClassLoaderService classLoaderService = new ClassLoaderServiceImpl(appClassLoaders) {
+            @Override
+            public <S> Collection<S> loadJavaServices(Class<S> serviceContract) {
+                if(MetadataContributor.class.isAssignableFrom(serviceContract)) {
+                    return Collections.<S>singletonList((S) domainBinder);
+                }
+                else {
+                    return super.loadJavaServices(serviceContract);
+                }
+            }
+        };
+        EventListenerIntegrator eventListenerIntegrator = new EventListenerIntegrator(hibernateEventListeners, eventListeners);
+        BootstrapServiceRegistry bootstrapServiceRegistry = new BootstrapServiceRegistryBuilder()
+                .applyIntegrator(eventListenerIntegrator)
+                .applyClassLoaderService(classLoaderService)
+                .build();
+
+        MetadataSources ms = new MetadataSources(bootstrapServiceRegistry);
+
+        try
+        {
+            HibernateMappingContextConfiguration configuration = BeanUtils.instantiateClass(configClass.getConstructor(MetadataSources.class),ms);
+            for(Object key : getProperties().keySet()) {
+                configuration.getProperties().put(key,getProperties().get(key));
+            }
+            return configuration;
+
+        } catch (NoSuchMethodException e)
+        {
+            throw new RuntimeException("There is no constructor in configClass which takes a single MetadataSources parameter.");
+        }
+
+
+    }
+
+
+}

--- a/grails-datastore-gorm-hibernate5/src/main/resources/META-INF/services/org.hibernate.boot.spi.MetadataBuilderInitializer
+++ b/grails-datastore-gorm-hibernate5/src/main/resources/META-INF/services/org.hibernate.boot.spi.MetadataBuilderInitializer
@@ -1,0 +1,1 @@
+org.grails.orm.hibernate.boot.spi.GrailsMetadataBuilderInitializer


### PR DESCRIPTION
Gorm 5 does not support JPA entities mapped in hibernate.cfg.xml. Actually if the JPA classes are in an external JAR, this is by design impossible because GORM 5 uses AST transformations during compile phase. But in theory, this must be possible if the JPA classes are passed through the same transformation. I tried this with adding grails.gorm.Entity annotations on my JPA classes which are in src/groovy folder. My classes were transformed like standard Grails domain classes but the problem was, since this transformation adds GormEntity trait to the domain class, during schema generation, hibernate complains that it can not map some properties ( i.e. errors, dirtyPropertyNames etc. ). These properties actually come from the GormValidateable and DirtyCheckable traits and I can't ignore these with the JPA Transient annotation because they are added during the compilation phase.

The only way I could find to solve this was to customize how hibernate adds annotated classes to the Configuration class. And this is done by a ReflectionManager. So if we override the default JavaReflectionManager with ours, we can provide custom metadata for each annotated class so that we can ignore these properties. 

To be able to do this, current HibernateMappingContextConfigration class is not sufficient. Actually current implementation has some design flaws because of the Hibernate 5's bootstrapping changes. Hibernate 5's Configuration class uses an internal BootstrapServiceRegistry and StandardServiceRegistry which are private, and current HibernateMappingContextConfigration class ignores these during buildSessionFactory method by creating its own service registries which results in ignoring of hibernate.cfg.xml mapped classes. See configure(Url url) method for instance. It actually adds the mappings to its private StandardServiceRegistry class but this is ignored in buildSessionFactory method. The only way to make Hibernate 5 work with grails's hibernate.cfg.xml mappings is to provide the registry to the configuration object via the constructor. 

So, I had to create a bridge class called HibernateMappingContextConfigurationBuilder which is used by the SessionFactoryBean class and it generates a BootstrapServiceRegistry and MetadataSources objects, and gives the MetadataSources to the configuration object ( which is determined by the configClass ) through its constructor. 

Remaining issue is to supply a MetadataBuilderInitializer to override the JavaReflectionManager with ours. So we put a service description file to META-INF/services folder and Hibernate 5 locates this and applies to the MetadataBuilder.

This way, configuration object keeps using its internal private service registries and our custom ReflectionManager decides which properties to be ignored. Currently, I did a very basic check which ignores all metadata properties which has a name containing "DirtyCheckable" and "GormValidateable" because these were creating problems. Better way is to figure out which properties are coming from automatically applied Grails traits but Groovy trait implementation does not provide an easy way to do this.

To test this implementation, I created a new Grails 3.1.3 app, and in src/groovy I put this class

```
@Entity
@grails.gorm.annotation.Entity
class Region
{

    @Id
    @GeneratedValue
    Long id

    String name;

}

@Embeddable
class Address {

    @ManyToOne
    Region region

    @Column(length = 400)
    String streetAddress
}
```

And also I created a standard grails domain class User to test if JPA entities and Grails domain classes work together:


```
class User {

    Address address

    static embedded = ['address']


    static constraints = {
    }
}
```

In bootstrap.groovy, I tested this with the following:

```
class BootStrap {

    def init = { servletContext ->
        def us = new Region(name:'US')
        us.save()
        def user = new User(address: new Address(region: us, streetAddress: "PO 2321, dummy street"))
        user.save(flush:true)

        def insertedUser = User.withCriteria {
            eq 'address.region.id',us.id
        }.find()

        assert insertedUser != null
    }
    def destroy = {
    }
}
```

This works and all tables are created successfully. Only issue is Gorm automaticall adds the "version" column to the entities. And I didn't come up with a good way to ignore it because the user could also add a "version" column manually and there is no easy way to identify if that property comes from a trait or it's users' declared property. 

I could not create a thorough test case for this implementation because I am not very experienced on grails tests but if somebody can guide me on that, I want to test if this implementation works with various types of JPA mappings like MappedSuperClass and inheritance scenarios. And also I need to test if all GORM methods work as expected. 














