### PR TITLE
Second pass compile foreign keys after creating subclass foreign keys

### DIFF
--- a/grails-datastore-gorm-hibernate4/src/main/groovy/org/grails/orm/hibernate/cfg/HibernateMappingContextConfiguration.java
+++ b/grails-datastore-gorm-hibernate4/src/main/groovy/org/grails/orm/hibernate/cfg/HibernateMappingContextConfiguration.java
@@ -284,8 +284,8 @@ public class HibernateMappingContextConfiguration extends Configuration implemen
             }
         }
 
-        super.secondPassCompile();
         createSubclassForeignKeys();
+        super.secondPassCompile();
 
         configLocked = true;
     }


### PR DESCRIPTION
The referencedTable was null

https://github.com/liquibase/liquibase-hibernate/blob/d691bc976cc6b37570d40a640d0d4944c0b0f0b3/src/main/java/liquibase/ext/hibernate/snapshot/ForeignKeySnapshotGenerator.java#L46

was throwing an NPE as a result.