### PR TITLE
Issue #744 - `DirtyCheckable#listDirtyPropertyNames` remove the entity name as dirty property list

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/dirty/checking/DirtyCheckable.groovy
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/dirty/checking/DirtyCheckable.groovy
@@ -87,9 +87,10 @@ public trait DirtyCheckable {
      * @return A list of the dirty property names
      */
     List<String> listDirtyPropertyNames() {
+        def className = getClass().name
         if($changedProperties != null) {
             return Collections.unmodifiableList(
-                $changedProperties.keySet().findAll { String n -> n != getClass().name }.toList()
+                $changedProperties.keySet().findAll { String propertyName -> propertyName != className }.toList()
             )
         }
         return Collections.emptyList()

--- a/grails-datastore-gorm/src/test/groovy/org/grails/datastore/gorm/dirty/checking/DirtyCheckTransformationSpec.groovy
+++ b/grails-datastore-gorm/src/test/groovy/org/grails/datastore/gorm/dirty/checking/DirtyCheckTransformationSpec.groovy
@@ -213,6 +213,23 @@ class FundProduct {
             b.hasChanged()
             b.hasChanged("age")
     }
+
+    @Issue("https://github.com/grails/grails-data-mapping/issues/744")
+    void "Test that listDirtyPropertyNames does not include the entity name"() {
+        when: "A new book is created"
+            def book = new Book(title: "Book Title", releaseDate: new Date())
+            book.trackChanges()
+        then:"The object has no changes"
+            !book.hasChanged()
+        when: "The title is updated"
+            book.title = "Title (Edited)"
+            book.markDirty()
+        then: "The listDirtyPropertyNames should not include the class name"
+            book.hasChanged()
+            book.hasChanged("title")
+            !(book.class.name in book.listDirtyPropertyNames())
+            book.listDirtyPropertyNames().size() == 1
+    }
 }
 
 @DirtyCheck


### PR DESCRIPTION
    if($changedProperties != null) {
        return Collections.unmodifiableList(
                $changedProperties.keySet().findAll { String n -> n != getClass().name }.toList()
        )
    }

Invoking `getClass().name` inside the closure returns the closure name failing to filter the entity name.