### PR TITLE
Remove ExpandoMetaClass.enableGlobally because ExpandoMetaClass behav…

### DIFF
--- a/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/GormDatastoreSpec.groovy
+++ b/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/GormDatastoreSpec.groovy
@@ -33,7 +33,6 @@ abstract class GormDatastoreSpec extends Specification {
     Session session
 
     def setupSpec() {
-        ExpandoMetaClass.enableGlobally()
         setupClass = loadSetupClass()
     }
 

--- a/grails-datastore-gorm/src/main/groovy/grails/gorm/DetachedCriteria.groovy
+++ b/grails-datastore-gorm/src/main/groovy/grails/gorm/DetachedCriteria.groovy
@@ -241,6 +241,7 @@ class DetachedCriteria<T> implements QueryableCriteria<T>, Cloneable, Iterable<T
      */
     Criteria projections(@DelegatesTo(ProjectionList) Closure callable) {
         callable.delegate = projectionList
+        callable.resolveStrategy = Closure.DELEGATE_FIRST
         callable.call()
         return this
     }


### PR DESCRIPTION
…es differently than ClosureMetaClass which was causing tests to incorrectly pass.

Fix projections to call the correct methods on the delegate