### PR TITLE
fix for grails/grails-data-mapping#823

### DIFF
--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/events/AutoTimestampEventListener.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/events/AutoTimestampEventListener.java
@@ -77,6 +77,8 @@ public class AutoTimestampEventListener extends AbstractPersistenceEventListener
 
     @Override
     protected void onPersistenceEvent(final AbstractPersistenceEvent event) {
+        if (event.getEntity() == null) return;
+
         if (event.getEventType() == EventType.PreInsert) {
             beforeInsert(event.getEntity(), event.getEntityAccess());
         }


### PR DESCRIPTION
here the proposed guard to prevent the npe described in #823

i did not come up with a good unit test because that required `Datastore` and `MappingContext` instances which were not easy to contruct or mock.

i did a `publishToMavenLocal` and ran the failing sample app from #823 successfully against the built gdm `6.0.4.BUILD-SNAPSHOT` (app starts, no more npe).

thanks, zyro