### PR TITLE
change manual check to do an and rather than an or

### DIFF
--- a/grails-datastore-gorm-support/src/main/groovy/org/grails/orm/hibernate4/support/GrailsOpenSessionInViewInterceptor.java
+++ b/grails-datastore-gorm-support/src/main/groovy/org/grails/orm/hibernate4/support/GrailsOpenSessionInViewInterceptor.java
@@ -82,7 +82,7 @@ public class GrailsOpenSessionInViewInterceptor extends OpenSessionInViewInterce
         Session session = sessionHolder != null ? sessionHolder.getSession() : null;
         try {
             super.postHandle(request, model);
-            boolean isNotManual = session.getFlushMode() != FlushMode.MANUAL || session.getFlushMode() != FlushMode.COMMIT;
+            boolean isNotManual = session.getFlushMode() != FlushMode.MANUAL && session.getFlushMode() != FlushMode.COMMIT;
             if (session != null && isNotManual) {
                 logger.debug("Eagerly flushing Hibernate session");
                 session.flush();


### PR DESCRIPTION
An exception in session.flush() will set the flush mode to MANUAL in the finally block.  
GrailsExceptionResolver will catch the exception and GrailsOpenSessionInViewInterceptor will get call again, which will set isNotManual to true because of the or check.
Session.flush() gets run again and could throw an exception causing an infinite loop.

