### PR TITLE
Convert GString to String automatically for multipart requests

### DIFF
--- a/grails-datastore-rest-client/src/main/groovy/grails/plugins/rest/client/RequestCustomizer.groovy
+++ b/grails-datastore-rest-client/src/main/groovy/grails/plugins/rest/client/RequestCustomizer.groovy
@@ -382,6 +382,9 @@ class RequestCustomizer {
         else if (value instanceof InputStream) {
             value = new InputStreamResource(value)
         }
+        else if (value instanceof GString) {
+            value = value.toString()
+        }
         if( mvm[name] ) {
             mvm[name].add value    
         }


### PR DESCRIPTION
So users can provide a GString as a key/value for multipart, eg:

```groovy
rest.post(url) {
  contentType "application/x-www-form-urlencoded"
  somekey = "${value} xyz" //.toString()
}
````
