### PR TITLE
Fix removeFrom for collection of enums.

### DIFF
--- a/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/EnumHasManySpec.groovy
+++ b/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/EnumHasManySpec.groovy
@@ -29,6 +29,24 @@ class EnumHasManySpec extends GormDatastoreSpec{
         then:"The results are correct"
              Animal.findByName('zebra').traits.size() == 3
     }
+
+    void "Test removeFrom collection of enums"() {
+        setup:
+            Animal zebra = new Animal(name: 'zebra')
+            zebra.addToTraits(Trait.FOUR_LEGS)
+            zebra.addToTraits(Trait.TAIL)
+            zebra.addToTraits(Trait.STRIPES)
+
+        when:
+            zebra.removeFromTraits(Trait.FOUR_LEGS)
+            zebra.save(flush: true)
+
+        then:
+            zebra.traits.size() == 2
+            !zebra.traits.contains(Trait.FOUR_LEGS)
+            zebra.traits.contains(Trait.TAIL)
+            zebra.traits.contains(Trait.STRIPES)
+    }
 }
 
 @Entity

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormEnhancer.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormEnhancer.groovy
@@ -184,7 +184,7 @@ class GormEnhancer {
                         targetObject
                     }
                     mc."removeFrom${prop.capitilizedName}" = { arg ->
-                        if (javaClass.isInstance(arg)) {
+                        if (javaClass?.isInstance(arg) || isBasic) {
                             final targetObject = delegate
                             targetObject[prop.name]?.remove(arg)
                             if (targetObject instanceof DirtyCheckable) {


### PR DESCRIPTION
If you had, say, a OneToMany relationship to an enum type and tried to used the "removeFrom" method you would get the following error:

```
java.lang.NullPointerException: Cannot invoke method isInstance() on null object
	at org.grails.datastore.gorm.GormEnhancer.addAssociationMethods_closure2(GormEnhancer.groovy:187)
```