### PR TITLE
align flush mode with the configured one (follow-up for #898)

### DIFF
--- a/grails-datastore-gorm-support/src/main/groovy/org/grails/orm/hibernate5/support/HibernatePersistenceContextInterceptor.java
+++ b/grails-datastore-gorm-support/src/main/groovy/org/grails/orm/hibernate5/support/HibernatePersistenceContextInterceptor.java
@@ -182,7 +182,6 @@ public class HibernatePersistenceContextInterceptor implements PersistenceContex
             LOG.debug("Opening single Hibernate session in HibernatePersistenceContextInterceptor");
             Session session = getSession();
             HibernateRuntimeUtils.enableDynamicFilterEnablerIfPresent(sf, session);
-            session.setFlushMode(FlushMode.AUTO);
             TransactionSynchronizationManager.bindResource(sf, new SessionHolder(session));
         }
     }


### PR DESCRIPTION
instead of setting the flush mode statically to `AUTO`, we rely on `HibernateDatastore#openSession` to set it properly if a new session is created:
https://github.com/grails/gorm-hibernate5/blob/v6.1.3/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/HibernateDatastore.java#L469

if there is already an existing/transaction-bound session, its flush mode remains unchanged.

an important point i can think of: this change will cause immediate grails bootstrap errors for the users who use the default config (`hibernate.flush.mode`: `COMMIT`) but are persisting entities in `BootStrap#init` without using transactions and/or services (which worked previously because of `AUTO`).

the change is just for the `hibernate5` version of the `HibernatePersistenceContextInterceptor` because the `hibernate4` `HibernateDatastore#openSession` does not set the flush mode.

hope i did not miss something important. a quick review would be much appreciated!

thanks, zyro