### PR TITLE
Fix double nested path in error path

### DIFF
--- a/grails-datastore-gorm-support/src/main/groovy/org/grails/orm/hibernate/validation/HibernateDomainClassValidator.java
+++ b/grails-datastore-gorm-support/src/main/groovy/org/grails/orm/hibernate/validation/HibernateDomainClassValidator.java
@@ -105,7 +105,7 @@ public class HibernateDomainClassValidator extends GrailsDomainClassValidator im
                         Errors existingErrors = validateable.getErrors();
                         if(existingErrors != null && existingErrors.hasErrors()) {
                             for(FieldError error : existingErrors.getFieldErrors()) {
-                                String path = errors.getNestedPath() + propertyName + '.' + error.getField();
+                                String path = propertyName + '.' + error.getField();
                                 errors.rejectValue(path, error.getCode(), error.getArguments(), error.getDefaultMessage());
                             }
                         }


### PR DESCRIPTION
`org.springframework.validation.AbstractErrors` performs
`getNestedPath() + canonicalFieldName(field);` in `fixedField()` where the
field passed to the method is the path sent to `rejectValue`
therefore you end up with double nested path, which results in an error
when actually trying to resolved the property.