### PR TITLE
Add java.time.Instant to SimpleTypes

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/MappingFactory.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/MappingFactory.java
@@ -103,6 +103,7 @@ public abstract class MappingFactory<R extends Entity,T extends Property> {
             URL.class.getName(),
             UUID.class.getName(),
             "org.bson.types.ObjectId",
+            "java.time.Instant",
             "java.time.LocalDateTime",
             "java.time.LocalDate",
             "java.time.LocalTime",


### PR DESCRIPTION
I've been testing an application locally that uses Java 8 `Instant`s. When using Dynamic Finders, I am getting the error:

```
org.springframework.dao.InvalidDataAccessResourceUsageException: Cannot query [instant.test.Book] on non-existent property: dateCreated
at org.grails.datastore.mapping.simple.query.SimpleMapQuery.getValidProperty(SimpleMapQuery.groovy:751)
at org.grails.datastore.mapping.simple.query.SimpleMapQuery.executeSubQueryInternal(SimpleMapQuery.groovy:690)
at org.grails.datastore.mapping.simple.query.SimpleMapQuery.executeSubQuery(SimpleMapQuery.groovy:676)
at org.grails.datastore.mapping.simple.query.SimpleMapQuery.executeQuery(SimpleMapQuery.groovy:63)
at org.grails.datastore.mapping.query.Query.doList(Query.java:575)
at org.grails.datastore.mapping.query.Query.singleResult(Query.java:563)
at org.grails.datastore.gorm.finders.CountByFinder.invokeQuery(CountByFinder.java:55)
at org.grails.datastore.gorm.finders.CountByFinder$1.doInSession(CountByFinder.java:49)
at org.grails.datastore.mapping.core.DatastoreUtils.execute(DatastoreUtils.java:319)
at org.grails.datastore.gorm.finders.AbstractFinder.execute(AbstractFinder.java:42)
at org.grails.datastore.gorm.finders.CountByFinder.doInvokeInternal(CountByFinder.java:46)
at org.grails.datastore.gorm.finders.DynamicFinder.invoke(DynamicFinder.java:174)
at org.grails.datastore.gorm.finders.DynamicFinder.invoke(DynamicFinder.java:374)
at org.grails.datastore.gorm.GormStaticApi.methodMissing(GormStaticApi.groovy:186)
at org.grails.datastore.gorm.GormEntity$Trait$Helper.staticMethodMissing(GormEntity.groovy:748)
at instant.test.BookSpec.Test can use Java 8 date types with Dynamic Finders(BookSpec.groovy:39)
```

Getting to the core of the issue, it seems that `java.time.Instant` is not considered a simple type and therefore not created as a property.

Manually adding this to the properties (via a breakpoint) proves this works.

Reference project (with currently failing test demonstrating issue: https://github.com/acanby/instant-test)

Original commit adding the Java 8 Time types: https://github.com/grails/grails-data-mapping/pull/790