### PR TITLE
Check if the associated object has already been validated

### DIFF
--- a/grails-datastore-gorm-validation/src/main/groovy/grails/gorm/validation/PersistentEntityValidator.groovy
+++ b/grails-datastore-gorm-validation/src/main/groovy/grails/gorm/validation/PersistentEntityValidator.groovy
@@ -109,7 +109,9 @@ class PersistentEntityValidator implements CascadingValidator, ConstrainedEntity
         if (association instanceof ToOne) {
             Object associatedObject = reflector.getProperty(parent, propertyName)
 
-            if(associatedObject != null && proxyHandler?.isInitialized(associatedObject)) {
+            // Prevent the cascade of validation in the event the associated object has already been validated
+            // This shouldn't happen, but it is possible and will cause an OOM error when adding errors
+            if(associatedObject != null && proxyHandler?.isInitialized(associatedObject) && !validatedObjects.contains(associatedObject)) {
                 if(association.isOwningSide() || association.doesCascade(CascadeType.PERSIST, CascadeType.MERGE)) {
                     cascadeValidationToOne(parent, propertyName, (ToOne)association, errors, reflector, associatedObject, null, validatedObjects)
                 }


### PR DESCRIPTION
It is possible for associatedObject to already have been validated
and therefore, without this check, we end up re-validating it and
potentially creating an OutOfMemory error due to nested paths when
creating/adding the errors.
This is only an issue when there are errors present, when there are
no errors the re-validation is not a problem, other than wasting time.