### PR TITLE
Add @DelegatesTo to and/or/not methods of Criteria

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/api/Criteria.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/api/Criteria.java
@@ -15,6 +15,7 @@
 package org.grails.datastore.mapping.query.api;
 
 import groovy.lang.Closure;
+import goovy.lang.DelegatesTo;
 import org.grails.datastore.mapping.query.Query;
 
 import java.util.Collection;

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/api/Criteria.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/api/Criteria.java
@@ -15,7 +15,7 @@
 package org.grails.datastore.mapping.query.api;
 
 import groovy.lang.Closure;
-import goovy.lang.DelegatesTo;
+import groovy.lang.DelegatesTo;
 import org.grails.datastore.mapping.query.Query;
 
 import java.util.Collection;

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/api/Criteria.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/api/Criteria.java
@@ -208,21 +208,21 @@ public interface Criteria  {
      *
      * @return This criteria
      */
-    Criteria and(Closure callable);
+    Criteria and(@DelegatesTo(Criteria) Closure callable);
 
     /**
      * Creates a logical disjunction
      * @param callable The closure
      * @return This criteria
      */
-    Criteria or(Closure callable);
+    Criteria or(@DelegatesTo(Criteria) Closure callable);
 
     /**
      * Creates a logical negation
      * @param callable The closure
      * @return This criteria
      */
-    Criteria not(Closure callable);
+    Criteria not(@DelegatesTo(Criteria) Closure callable);
 
     /**
      * Creates an "in" Criterion based on the specified property name and list of values


### PR DESCRIPTION
Static type checking seems to fall down as soon as you try to use an and/or/not in a Buildable criteria. I noticed that these methods lack the @DelegatesTo(Criteria) annotation that withCriteria provides.

E.G.
```
Person.createCriteria().list {
    eq 'firstName', 'John' 
    or {
        eq 'lastName', 'Smith'
        isNull 'lastName'
    }
}
````