### PR TITLE
Issue #878: backport of "make UUID a simple type" from GORM 5&6 to GORM 3

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/MappingFactory.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/MappingFactory.java
@@ -117,6 +117,7 @@ public abstract class MappingFactory<R extends Entity,T extends Property> {
             Serializable.class.getName(),
             URI.class.getName(),
             URL.class.getName(),
+            UUID.class.getName(),
             "org.bson.types.ObjectId")));
     }
 

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/MappingFactory.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/model/MappingFactory.java
@@ -24,15 +24,7 @@ import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.GregorianCalendar;
-import java.util.HashSet;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.TimeZone;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.grails.datastore.mapping.config.Entity;


### PR DESCRIPTION
Simple cherry pick backport of 8f680cde976348d27ce690f289df469e2efa8ec5 commit to GORM 3.x branch, from GORM 5 backport from GORM 6 fix