### PR TITLE
Prevent calling getScale() for multi-column properties unnecessarily

### DIFF
--- a/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/cfg/HibernateMappingBuilder.groovy
+++ b/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/cfg/HibernateMappingBuilder.groovy
@@ -475,8 +475,12 @@ class HibernateMappingBuilder implements MappingConfigurationBuilder<Mapping, Pr
             property.max = namedArgs.max instanceof Comparable ? namedArgs.max : property.max
             property.min = namedArgs.min instanceof Comparable ? namedArgs.min : property.min
             property.range = namedArgs.range instanceof ObjectRange ? namedArgs.range : null
-            property.scale = namedArgs.scale instanceof Integer ? namedArgs.scale : property.scale
             property.inList = namedArgs.inList instanceof List ? namedArgs.inList : property.inList
+
+            // Need to guard around calling getScale() for multi-column properties (issue #1048)
+            if (namedArgs.scale instanceof Integer) {
+                property.scale = (Integer)namedArgs.scale
+            }
 
             if (namedArgs.fetch) {
                 switch(namedArgs.fetch) {

--- a/grails-datastore-gorm-hibernate-core/src/test/groovy/grails/gorm/hibernate/mapping/HibernateMappingBuilderTests.groovy
+++ b/grails-datastore-gorm-hibernate-core/src/test/groovy/grails/gorm/hibernate/mapping/HibernateMappingBuilderTests.groovy
@@ -5,6 +5,7 @@ package grails.gorm.hibernate.mapping
  */
 import org.grails.orm.hibernate.cfg.CompositeIdentity
 import org.grails.orm.hibernate.cfg.HibernateMappingBuilder
+import org.grails.orm.hibernate.cfg.Mapping
 import org.grails.orm.hibernate.cfg.PropertyConfig
 import org.hibernate.FetchMode
 
@@ -692,6 +693,43 @@ class HibernateMappingBuilderTests extends GroovyTestCase {
 
         shouldFail { mapping.columns.amount.column }
         shouldFail { mapping.columns.amount.sqlType }
+    }
+
+    void testConstrainedPropertyWithMultipleColumns() {
+        def builder = new HibernateMappingBuilder("Foo")
+        builder.evaluate {
+            amount type: MyUserType, {
+                column name: "value"
+                column name: "currency", sqlType: "char", length: 3
+            }
+        }
+        def mapping = builder.evaluate {
+            amount nullable: true
+        }
+
+        assertEquals 2, mapping.columns.amount.columns.size()
+        assertEquals "value", mapping.columns.amount.columns[0].name
+        assertEquals "currency", mapping.columns.amount.columns[1].name
+        assertEquals "char", mapping.columns.amount.columns[1].sqlType
+        assertEquals 3, mapping.columns.amount.columns[1].length
+
+        shouldFail { mapping.columns.amount.column }
+        shouldFail { mapping.columns.amount.sqlType }
+    }
+
+    void testDisallowedConstrainedPropertyWithMultipleColumns() {
+        def builder = new HibernateMappingBuilder("Foo")
+        builder.evaluate {
+            amount type: MyUserType, {
+                column name: "value"
+                column name: "currency", sqlType: "char", length: 3
+            }
+        }
+        shouldFail {
+            builder.evaluate {
+                amount scale: 2
+            }
+        } == "Cannot treat multi-column property as a single-column property"
     }
 
     void testPropertyWithUserTypeAndNoParams() {

--- a/grails-datastore-gorm-hibernate-core/src/test/groovy/grails/gorm/hibernate/mapping/HibernateMappingBuilderTests.groovy
+++ b/grails-datastore-gorm-hibernate-core/src/test/groovy/grails/gorm/hibernate/mapping/HibernateMappingBuilderTests.groovy
@@ -5,7 +5,6 @@ package grails.gorm.hibernate.mapping
  */
 import org.grails.orm.hibernate.cfg.CompositeIdentity
 import org.grails.orm.hibernate.cfg.HibernateMappingBuilder
-import org.grails.orm.hibernate.cfg.Mapping
 import org.grails.orm.hibernate.cfg.PropertyConfig
 import org.hibernate.FetchMode
 
@@ -725,7 +724,7 @@ class HibernateMappingBuilderTests extends GroovyTestCase {
                 column name: "currency", sqlType: "char", length: 3
             }
         }
-        shouldFail {
+        assert shouldFail {
             builder.evaluate {
                 amount scale: 2
             }


### PR DESCRIPTION
Fixes #1048 