### PR TITLE
Fix createNamedQuery initialization for multi-threaded environment

### DIFF
--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormEnhancer.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormEnhancer.groovy
@@ -225,20 +225,15 @@ class GormEnhancer implements Closeable {
                         def evaluator = new NamedQueriesBuilder()
                         namedQueries = evaluator.evaluate(closure)
                         NAMED_QUERIES.put(className, namedQueries)
-                        return buildNamedCriteriaProxy(entity, namedQueries, queryName, args)
                     }
                     else {
                         NAMED_QUERIES.put(className, Collections.emptyMap())
+                        return null
                     }
                 }
-
-            }
-
-        }
-        else {
-            return buildNamedCriteriaProxy(entity, namedQueries, queryName, args)
-        }
-        return null
+	    }
+        }        
+        return buildNamedCriteriaProxy(entity, namedQueries, queryName, args)
     }
 
     private static NamedCriteriaProxy buildNamedCriteriaProxy(Class entity, Map<String, Closure> namedQueries, String queryName, Object... args) {


### PR DESCRIPTION
Current `createNamedQuery` implementation behaves incorrect when called for the same class in multiple threads. When it enters in `synchronized` block it double checks `namedQueries` and if it was already initialized in another thread while blocking it just does nothing and returns `null`, but should instead return call `buildNamedCriteriaProxy` for `namedQueries` re-obtained from `NAMED_QUERIES` map.