### PR TITLE
Fix apply default constraints for embedded POGO properties

### DIFF
--- a/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/EmbeddedAssociationWithNoEntityAndGlobalNullableConstraintSpec.groovy
+++ b/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/EmbeddedAssociationWithNoEntityAndGlobalNullableConstraintSpec.groovy
@@ -1,0 +1,70 @@
+package org.grails.datastore.gorm
+
+import grails.gorm.tests.GormDatastoreSpec
+import grails.gorm.validation.PersistentEntityValidator
+import grails.persistence.Entity
+import org.grails.datastore.gorm.validation.constraints.eval.DefaultConstraintEvaluator
+import org.grails.datastore.gorm.validation.constraints.registry.DefaultValidatorRegistry
+import org.grails.datastore.mapping.config.Settings
+import org.grails.datastore.mapping.core.DatastoreUtils
+import org.grails.datastore.mapping.model.PersistentEntity
+import org.grails.datastore.mapping.simple.SimpleMapDatastore
+import org.springframework.context.MessageSource
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+
+class EmbeddedAssociationWithNoEntityAndGlobalNullableConstraintSpec extends GormDatastoreSpec {
+
+    @Shared @AutoCleanup SimpleMapDatastore datastore = new SimpleMapDatastore(
+        DatastoreUtils.createPropertyResolver((Settings.SETTING_DEFAULT_CONSTRAINTS): { '*'(nullable: true) }),
+        [],
+        User2
+    )
+
+    void "global constraints are applied to embedded properties defined as POGO"() {
+        given:
+        def user = new User2()
+        user.username = 'admin'
+        user.address.city = 'Madrid'
+
+        def context = datastore.mappingContext
+        context.setValidatorRegistry(new DefaultValidatorRegistry(context, datastore.getConnectionSources().getDefaultConnectionSource().settings))
+
+        PersistentEntity entityUser = datastore.getMappingContext().getPersistentEntity(User2.name)
+        def validatorUser = new PersistentEntityValidator(entityUser, Mock(MessageSource), new DefaultConstraintEvaluator())
+        session.datastore.mappingContext.addEntityValidator(entityUser, validatorUser)
+
+        PersistentEntity entityAddress = datastore.getMappingContext().getPersistentEntity(User2.name)
+        def validatorAddress = new PersistentEntityValidator(entityAddress, Mock(MessageSource), new DefaultConstraintEvaluator())
+        session.datastore.mappingContext.addEntityValidator(entityAddress, validatorAddress)
+
+        when:
+        user.validate()
+
+        then:
+        !user.hasErrors()
+    }
+
+    @Override
+    List getDomainClasses() {
+        [User2]
+    }
+}
+
+@Entity
+class User2 {
+    Long id
+    String username
+    String password
+    Address2 address = new Address2()
+
+    static embedded = ['address']
+
+    static mapping = {
+    }
+}
+
+class Address2 {
+    String city
+    String postCode
+}

--- a/grails-datastore-gorm-validation/src/main/groovy/org/grails/datastore/gorm/validation/constraints/eval/DefaultConstraintEvaluator.java
+++ b/grails-datastore-gorm-validation/src/main/groovy/org/grails/datastore/gorm/validation/constraints/eval/DefaultConstraintEvaluator.java
@@ -164,7 +164,9 @@ public class DefaultConstraintEvaluator implements ConstraintsEvaluator {
                         constrainedProperty.setOrder(constrainedProperties.size() + 1);
                         constrainedProperties.put(propertyName, constrainedProperty);
                         applyDefaultConstraints(propertyName, null, constrainedProperty, defaultConstraints);
-                        applyDefaultNullableConstraint(constrainedProperty, defaultNullable);
+                        if (!constrainedProperty.hasAppliedConstraint(ConstrainedProperty.NULLABLE_CONSTRAINT)) {
+                            applyDefaultNullableConstraint(constrainedProperty, defaultNullable);
+                        }
                     }
                 }
             }

--- a/grails-datastore-gorm-validation/src/main/groovy/org/grails/datastore/gorm/validation/constraints/eval/DefaultConstraintEvaluator.java
+++ b/grails-datastore-gorm-validation/src/main/groovy/org/grails/datastore/gorm/validation/constraints/eval/DefaultConstraintEvaluator.java
@@ -163,8 +163,8 @@ public class DefaultConstraintEvaluator implements ConstraintsEvaluator {
                         DefaultConstrainedProperty constrainedProperty = new DefaultConstrainedProperty(theClass, propertyName, propertyType, constraintRegistry);
                         constrainedProperty.setOrder(constrainedProperties.size() + 1);
                         constrainedProperties.put(propertyName, constrainedProperty);
-                        applyDefaultNullableConstraint(constrainedProperty, defaultNullable);
                         applyDefaultConstraints(propertyName, null, constrainedProperty, defaultConstraints);
+                        applyDefaultNullableConstraint(constrainedProperty, defaultNullable);
                     }
                 }
             }


### PR DESCRIPTION
This still is a work in progress to fix this issue https://github.com/grails/grails-core/issues/10867.
I'm not really sure how to create the failing test before fixing the issue. There is something wrong about how I create the global constraint because when debugging the default constraints are not there.

Another thing I'm not really sure is all the "wiring" I'm doing in the test with `PersistentEntity` and `PersistentEntityValidator`. If I don't do this then when I execute `user.validate()` the implementation is `GormValidationApi` but when I debug the issue in a real application the implementation is `HibernateGormValidationApi`.

In any case, I think the issue is here: https://github.com/grails/grails-data-mapping/blob/4957afb5ffb215845b2a846f94020cd09693199d/grails-datastore-gorm-validation/src/main/groovy/org/grails/datastore/gorm/validation/constraints/eval/DefaultConstraintEvaluator.java#L166-L167 because `applyDefaultNullableConstraint` is called before `applyDefaultConstraints` so when we tried to apply the global constraint here: https://github.com/grails/grails-data-mapping/blob/4957afb5ffb215845b2a846f94020cd09693199d/grails-datastore-gorm-validation/src/main/groovy/org/grails/datastore/gorm/validation/constraints/eval/DefaultConstraintEvaluator.java#L252-L267 `cp.hasAppliedConstraint(constraintName)` returns `true` and the constraint it's not applied.
I think the order of those methods is not right because here:

https://github.com/grails/grails-data-mapping/blob/4957afb5ffb215845b2a846f94020cd09693199d/grails-datastore-gorm-validation/src/main/groovy/org/grails/datastore/gorm/validation/constraints/eval/DefaultConstraintEvaluator.java#L131

and here:

https://github.com/grails/grails-data-mapping/blob/4957afb5ffb215845b2a846f94020cd09693199d/grails-datastore-gorm-validation/src/main/groovy/org/grails/datastore/gorm/validation/constraints/eval/DefaultConstraintEvaluator.java#L142

`applyDefaultConstraints` is executed before `applyDefaultNullableConstraint`.

Even if I'm not able to create the test to reproduce the issue I've tried my fix with the sample application from the issue and this solves it. I've also run all the tests in `grails-data-mapping` repo and all still pass with my change.

Can you please help me with the test so I can reproduce the issue?



