### PR TITLE
We need to check that the associatedPersistentProperty cascades

### DIFF
--- a/grails-datastore-gorm-validation/src/main/groovy/grails/gorm/validation/PersistentEntityValidator.groovy
+++ b/grails-datastore-gorm-validation/src/main/groovy/grails/gorm/validation/PersistentEntityValidator.groovy
@@ -245,7 +245,7 @@ class PersistentEntityValidator implements CascadingValidator, ConstrainedEntity
                     continue
                 }
                 if (associatedPersistentProperty instanceof Association) {
-                    if(association.doesCascade(CascadeType.PERSIST, CascadeType.MERGE)) {
+                    if(((Association)associatedPersistentProperty).doesCascade(CascadeType.PERSIST, CascadeType.MERGE)) {
                         if(association.isBidirectional() && associatedPersistentProperty == association.inverseSide) {
                             // If this property is the inverse side of the currently processed association then
                             // we don't want to process it because that would cause a potential infinite loop


### PR DESCRIPTION
Currently we check if the current association cascades, which isn't
relevant to the actual property being validated, we should be checking the associatedPersistentProperty which we know is an association