### PR TITLE
throwing proper exception

### DIFF
--- a/grails-datastore-gorm-validation/src/main/groovy/grails/gorm/validation/PersistentEntityValidator.groovy
+++ b/grails-datastore-gorm-validation/src/main/groovy/grails/gorm/validation/PersistentEntityValidator.groovy
@@ -48,10 +48,10 @@ class PersistentEntityValidator implements CascadingValidator, ConstrainedEntity
         this.proxyHandler = mappingContext.getProxyHandler()
 
         def evaluated = constraintsEvaluator.evaluate(targetClass)
-        this.constrainedProperties = Collections.unmodifiableMap(evaluated)
-        if(constrainedProperties == null) {
+        if (evaluated == null) {
             throw new IllegalStateException("Constraint evaluator returned null for class: $targetClass")
         }
+        this.constrainedProperties = Collections.unmodifiableMap(evaluated)
     }
 
     @Override


### PR DESCRIPTION
when constrained properties are `null`

current implementation would throw `NullPointerException` from `Collections.unmodifiableMap(evaluated)`

`constrainedProperties` is never `null` in following construct
```
this.constrainedProperties = Collections.unmodifiableMap(evaluated)
if(constrainedProperties == null) {
```

maybe I'm missing something (different implementation of `unmodifiableMap` between JDK versions?)