### PR TITLE
Set transaction name when using @Transactional annotation

### DIFF
--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/transactions/transform/TransactionalTransform.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/transactions/transform/TransactionalTransform.groovy
@@ -327,7 +327,7 @@ class TransactionalTransform extends AbstractDatastoreMethodDecoratingTransforma
         )
 
         // apply @Transaction attributes to properties of $transactionAttribute
-        applyTransactionalAttributeSettings(annotationNode, transactionAttributeVar, newMethodBody)
+        applyTransactionalAttributeSettings(annotationNode, transactionAttributeVar, newMethodBody, classNode, methodNode)
 
         boolean isMultiTenant = TenantTransform.hasTenantAnnotation(methodNode)
 
@@ -387,7 +387,7 @@ class TransactionalTransform extends AbstractDatastoreMethodDecoratingTransforma
         return "execute"
     }
 
-    protected applyTransactionalAttributeSettings(AnnotationNode annotationNode, VariableExpression transactionAttributeVar, BlockStatement methodBody) {
+    protected applyTransactionalAttributeSettings(AnnotationNode annotationNode, VariableExpression transactionAttributeVar, BlockStatement methodBody, ClassNode classNode, MethodNode methodNode) {
         final ClassNode rollbackRuleAttributeClassNode = make(RollbackRuleAttribute)
         final ClassNode noRollbackRuleAttributeClassNode = make(NoRollbackRuleAttribute)
         final Map<String, Expression> members = annotationNode.getMembers()
@@ -424,6 +424,11 @@ class TransactionalTransform extends AbstractDatastoreMethodDecoratingTransforma
                 }
             }
         }
+
+        final transactionName = classNode.name + '.' + methodNode.name
+        methodBody.addStatement(
+            assignS(propX(transactionAttributeVar, 'name'), new ConstantExpression(transactionName))
+        )
     }
 
     private void appendRuleElement(BlockStatement methodBody, VariableExpression transactionAttributeVar, String name, Expression expr) {

--- a/grails-datastore-gorm/src/test/groovy/grails/gorm/annotation/transactions/TransactionalTransformSpec.groovy
+++ b/grails-datastore-gorm/src/test/groovy/grails/gorm/annotation/transactions/TransactionalTransformSpec.groovy
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.CommonAnnotationBeanPostProcessor
 import org.springframework.jdbc.datasource.DataSourceTransactionManager
 import org.springframework.jdbc.datasource.DriverManagerDataSource
 import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.TransactionStatus
 import org.springframework.transaction.UnexpectedRollbackException
 import org.springframework.transaction.support.DefaultTransactionStatus
@@ -927,6 +928,60 @@ new BookService()
         status.isRollbackOnly()
     }
 
+    void "Test that a @Transactional annotation on a method sets name of transaction"() {
+        given:"A new instance of a class with a @Transactional method is created"
+        def bookService = new GroovyShell().evaluate('''
+package foo
+import grails.gorm.transactions.*
+class BookService {
+    @Transactional
+    void updateBook() {
+    }
+}
+new BookService()
+''')
+
+        when:"A transactionManager is set"
+        final transactionManager = getPlatformTransactionManager()
+        bookService.transactionManager = transactionManager
+
+        then:"It is not null"
+        bookService.transactionManager != null
+
+        when:"When a transactional method is called"
+        bookService.updateBook()
+
+        then:"transaction name is foo.BookService.updateBook"
+        transactionManager.definition.name == 'foo.BookService.updateBook'
+    }
+
+    void "Test that a @Transactional annotation on a class sets name of transaction"() {
+        given:"A new instance of a class with a @Transactional method is created"
+        def bookService = new GroovyShell().evaluate('''
+package foo
+import grails.gorm.transactions.*
+@Transactional
+class BookService {
+    void updateBook() {
+    }
+}
+new BookService()
+''')
+
+        when:"A transactionManager is set"
+        final transactionManager = getPlatformTransactionManager()
+        bookService.transactionManager = transactionManager
+
+        then:"It is not null"
+        bookService.transactionManager != null
+
+        when:"When a method on a transactional class is called"
+        bookService.updateBook()
+
+        then:"transaction name is foo.BookService.updateBook"
+        transactionManager.definition.name == 'foo.BookService.updateBook'
+    }
+
     void 'test CompileStatic on a method in a class marked with Transactional'() {
         given:
         def gcl = new GroovyClassLoader()
@@ -1059,6 +1114,7 @@ class TransactionalTransformSpecService implements InitializingBean {
 class TestTransactionManager extends DataSourceTransactionManager {
     boolean transactionStarted = false
     boolean transactionRolledBack = false
+    TransactionDefinition definition = null
 
     TestTransactionManager(DataSource dataSource) {
         super(dataSource)
@@ -1074,6 +1130,12 @@ class TestTransactionManager extends DataSourceTransactionManager {
     protected void doRollback(DefaultTransactionStatus status) {
         transactionRolledBack = true
         super.doRollback(status)
+    }
+
+    @Override
+    protected void doBegin(Object transaction, TransactionDefinition definition) {
+        this.definition = definition
+        super.doBegin(transaction, definition)
     }
 }
 


### PR DESCRIPTION
Currently, when using `@Transactional` annotation, name of the transaction stays null. This does not comply with Spring's `@Transactional` annotation, which sets name of the transaction equal to fully-qualified class name + "." + method name.

This PR fixes this problem.