### PR TITLE
Fix #1094, flag formula property as derived in unit tests

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/mapping/config/GormKeyValueMappingFactory.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/keyvalue/mapping/config/GormKeyValueMappingFactory.java
@@ -15,11 +15,11 @@
 package org.grails.datastore.mapping.keyvalue.mapping.config;
 
 import org.grails.datastore.mapping.config.AbstractGormMappingFactory;
-import org.grails.datastore.mapping.config.Property;
 import org.grails.datastore.mapping.model.ClassMapping;
 import org.grails.datastore.mapping.model.IdentityMapping;
 import org.grails.datastore.mapping.model.PersistentEntity;
 import org.grails.datastore.mapping.model.PersistentProperty;
+import org.grails.datastore.mapping.model.PropertyMapping;
 
 /**
  * @author Graeme Rocher
@@ -56,6 +56,16 @@ public class GormKeyValueMappingFactory extends AbstractGormMappingFactory<Famil
     }
 
     @Override
+    protected PropertyMapping<KeyValue> createPropertyMapping(final PersistentProperty<KeyValue> property, final PersistentEntity owner) {
+        PropertyMapping<KeyValue> mapping = super.createPropertyMapping(property, owner);
+        if (mapping.getMappedForm().getFormula() != null) {
+            mapping.getMappedForm().setDerived(true);
+        }
+
+        return mapping;
+    }
+
+    @Override
     protected Class<KeyValue> getPropertyMappedFormType() {
         return KeyValue.class;
     }
@@ -69,8 +79,7 @@ public class GormKeyValueMappingFactory extends AbstractGormMappingFactory<Famil
     protected IdentityMapping getIdentityMappedForm(final ClassMapping classMapping, KeyValue property) {
         if (property != null) {
             return createDefaultIdentityMapping(classMapping, property);
-        }
-        else {
+        } else {
             return super.getIdentityMappedForm(classMapping, null);
         }
     }

--- a/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/keyvalue/mapping/KeyValueMappingFactoryTests.groovy
+++ b/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/keyvalue/mapping/KeyValueMappingFactoryTests.groovy
@@ -4,6 +4,7 @@ import org.grails.datastore.mapping.keyvalue.mapping.config.Family
 import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValue
 import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValueMappingContext
 import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValuePersistentEntity
+import org.grails.datastore.mapping.model.PersistentProperty
 import org.junit.Before
 import org.junit.Test
 
@@ -19,6 +20,7 @@ class KeyValueMappingFactoryTests {
         context = new KeyValueMappingContext("myspace")
         context.addPersistentEntity(TestEntity)
         context.addPersistentEntity(AbstractTestEntity)
+        context.addPersistentEntity(FormulaTestEntity)
     }
 
     @Test
@@ -37,6 +39,24 @@ class KeyValueMappingFactoryTests {
     }
 
     @Test
+    void testEntityWithFormula() {
+        KeyValuePersistentEntity entity = context.getPersistentEntity(FormulaTestEntity.name)
+        assert entity != null
+
+        KeyValue kv = entity.identity.mapping.mappedForm as KeyValue
+        assert kv != null
+        assert kv.key == 'id'
+
+        PersistentProperty prop = entity.getPropertyByName('nonFormulaProperty')
+        assert !prop.mapping.mappedForm.derived
+        assert !prop.mapping.mappedForm.nullable
+
+        // Formula properties should be flagged as derived
+        prop = entity.getPropertyByName('formulaProperty')
+        assert prop.mapping.mappedForm.derived
+    }
+
+    @Test
     void testParentEntity() {
         KeyValuePersistentEntity entity = context.getPersistentEntity(TestEntity.name)
         assert entity != null
@@ -51,5 +71,14 @@ class KeyValueMappingFactoryTests {
 
     class TestEntity extends AbstractTestEntity {
         Long version
+    }
+
+    class FormulaTestEntity extends AbstractTestEntity {
+        String nonFormulaProperty
+        String formulaProperty
+
+        static mapping = {
+            formulaProperty(formula: 'foo(bar)')
+        }
     }
 }


### PR DESCRIPTION
Fixes #1094 which allows domain objects with `formula` properties to be created in unit tests without essentially defaulting to `nullable: false`.