### PR TITLE
Fix #1104 - ConstrainedProperty types always Object for to-one

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/reflect/ClassPropertyFetcher.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/reflect/ClassPropertyFetcher.java
@@ -273,7 +273,9 @@ public class ClassPropertyFetcher {
                 return null;
             }
             else {
-                return metaProperty.getType();
+                // Avoid any proxy handling that might be wrapped around the getters and setters
+                Field field = getDeclaredField(name);
+                return field != null ? field.getType() : metaProperty.getType();
             }
         }
         return null;

--- a/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/reflect/ClassPropertyFetcherTests.groovy
+++ b/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/reflect/ClassPropertyFetcherTests.groovy
@@ -68,6 +68,26 @@ class ClassPropertyFetcherTests  {
 
     }
 
+    @Test
+    void testGetObjectTypeForWrappedBeanProperty() {
+        GroovyObject mc = (GroovyObject)Foo.metaClass
+
+        // Wrap the getter and setter similar to how they'd be wrapped for hibernate proxy handling
+        mc.setProperty("getBar", {->
+            delegate.@bar
+        })
+        mc.setProperty("setBar", {
+            delegate.@bar = it
+        })
+
+        // The default meta property type is Object
+        assert Foo.metaClass.getMetaProperty('bar').getType() == Object
+
+        // The class property fetcher returns the real type via the Field
+        def cpf = ClassPropertyFetcher.forClass(Foo)
+        assert cpf.getPropertyType('bar') == String
+    }
+
     static class Foo {
         static String name = "foo"
 


### PR DESCRIPTION
There might be a better way to handle this specifically in the `ConstrainedPropertyBuilder` but the root cause is definitely that the metaClass wrappers for setters and getters for hibernate proxies causes the CPF to always see `Object` for the root type. Since we tend to leave the fields themselves alone for bean properties, it seems safe to use the field type if it's a field and then fallback to just the property type.