### PR TITLE
Fix #1106, GORM cascades validations too aggressively

### DIFF
--- a/grails-datastore-gorm-test/src/test/groovy/grails/gorm/tests/CircularCascadeSpec.groovy
+++ b/grails-datastore-gorm-test/src/test/groovy/grails/gorm/tests/CircularCascadeSpec.groovy
@@ -144,6 +144,19 @@ class CircularCascadeSpec extends GormDatastoreSpec {
         activity.errors.hasFieldErrors('sports[0].arenas[0].name')
     }
 
+    @Issue('https://github.com/grails/grails-data-mapping/issues/1106')
+    void "test child associations are not validated unless owned or cascade-all"() {
+        given:
+        addValidator(ActivityValidate, SportValidate, CityValidate)
+        ActivityValidate activity = new ActivityValidate(name: "Game")
+        SportValidate sport = new SportValidate(name: 'Basketball')
+        sport.addToCities(new CityValidate())
+        activity.addToSports(sport)
+
+        expect:"valid since CityValidate should not be validated"
+        activity.validate()
+    }
+
     @Override
     List getDomainClasses() {
         [SchoolPerson, ActivityValidate, SportValidate, TeamValidate, ArenaValidate]
@@ -178,7 +191,14 @@ class ActivityValidate {
 class SportValidate {
     String name
 
-    static hasMany = [teams: TeamValidate, arenas: ArenaValidate]
+    static belongsTo = [activity: ActivityValidate]
+
+    static hasMany = [teams: TeamValidate, arenas: ArenaValidate, cities: CityValidate]
+
+    static mapping = {
+        teams(cascade: 'all')
+        arenas(cascade: 'all')
+    }
 }
 
 @Entity
@@ -188,5 +208,10 @@ class TeamValidate {
 
 @Entity
 class ArenaValidate {
+    String name
+}
+
+@Entity
+class CityValidate {
     String name
 }

--- a/grails-datastore-gorm-validation/src/main/groovy/grails/gorm/validation/PersistentEntityValidator.groovy
+++ b/grails-datastore-gorm-validation/src/main/groovy/grails/gorm/validation/PersistentEntityValidator.groovy
@@ -205,7 +205,7 @@ class PersistentEntityValidator implements CascadingValidator, ConstrainedEntity
         MappingContext mappingContext = associatedEntity.getMappingContext()
         EntityReflector associatedReflector = mappingContext.getEntityReflector(associatedEntity)
 
-        if (associatedEntity == null || (!association.isOwningSide() && !association.doesCascade(CascadeType.PERSIST, CascadeType.MERGE) )) {
+        if (associatedEntity == null || (!association.isOwningSide() && !association.doesCascade(CascadeType.ALL))) {
             return
         }
 

--- a/grails-datastore-gorm-validation/src/test/groovy/grails/gorm/validation/PersistentEntityValidatorSpec.groovy
+++ b/grails-datastore-gorm-validation/src/test/groovy/grails/gorm/validation/PersistentEntityValidatorSpec.groovy
@@ -82,12 +82,19 @@ class Author  {
     static constraints = {
         publisher(nullable: true)
     }
+
+    static mapping = {
+        // Only owned relationships or cascade-all are cascaded by default
+        publisher(cascade: 'all')
+    }
 }
 
 @Entity
 class Book {
     String name
     Author author
+
+    static belongsTo = [author: Author]
 
     def beforeValidate() {
         name = "name"


### PR DESCRIPTION
This could be a bit of a breaking change but it does return the behavior to closer to the Grails 2.x behavior which is way better from a performance standpoint, especially for large object graphs like we have on our project.

At least worth starting a discussion.

The two tests just needed additional mapping configuration so they would validate explicitly.