### PR TITLE
Issue 1099: Grails apps will not deploy to Glassfish 4+

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/AbstractDatastore.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/AbstractDatastore.java
@@ -108,7 +108,7 @@ public abstract class AbstractDatastore implements Datastore, StatelessDatastore
     }
 
     @PreDestroy
-    public void destroy() throws Exception {
+    public void destroy() {
         FieldEntityAccess.clearReflectors();
         final MetaClassRegistry registry = GroovySystem.getMetaClassRegistry();
         for (PersistentEntity persistentEntity : getMappingContext().getPersistentEntities()) {

--- a/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/AbstractHibernateDatastore.java
+++ b/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/AbstractHibernateDatastore.java
@@ -305,11 +305,15 @@ public abstract class AbstractHibernateDatastore extends AbstractDatastore imple
     }
 
     @Override
-    public void destroy() throws Exception {
-        if(!this.destroyed) {
+    public void destroy() {
+        if (!this.destroyed) {
             super.destroy();
             AbstractHibernateGormInstanceApi.resetInsertActive();
-            connectionSources.close();
+            try {
+                connectionSources.close();
+            } catch (IOException e) {
+                LOG.warn("There was an error shutting down GORM for an entity: " + e.getMessage(), e);
+            }
             destroyed = true;
         }
     }


### PR DESCRIPTION
Methods annotated with `@PreDestroy` should not throw a checked exception.

This is documented at https://docs.oracle.com/javaee/7/api/javax/annotation/PreDestroy.html