### PR TITLE
Issue 1099: Grails apps will not deploy to Glassfish 4+

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/AbstractDatastore.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/core/AbstractDatastore.java
@@ -108,7 +108,7 @@ public abstract class AbstractDatastore implements Datastore, StatelessDatastore
     }
 
     @PreDestroy
-    public void destroy() throws Exception {
+    public void destroy() {
         FieldEntityAccess.clearReflectors();
         final MetaClassRegistry registry = GroovySystem.getMetaClassRegistry();
         for (PersistentEntity persistentEntity : getMappingContext().getPersistentEntities()) {
@@ -116,7 +116,7 @@ public abstract class AbstractDatastore implements Datastore, StatelessDatastore
             try {
                 registry.removeMetaClass(cls);
             } catch (Exception e) {
-                LOG.warn("There was an error shutting down GORM for entity ["+cls.getName()+"]: " + e.getMessage(), e);
+                LOG.error("There was an error shutting down GORM for entity ["+cls.getName()+"]: " + e.getMessage(), e);
             }
         }
         ClassPropertyFetcher.clearCache();

--- a/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/AbstractHibernateDatastore.java
+++ b/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/AbstractHibernateDatastore.java
@@ -305,22 +305,26 @@ public abstract class AbstractHibernateDatastore extends AbstractDatastore imple
     }
 
     @Override
-    public void destroy() throws Exception {
-        if(!this.destroyed) {
+    public void destroy() {
+        if (!this.destroyed) {
             super.destroy();
             AbstractHibernateGormInstanceApi.resetInsertActive();
-            connectionSources.close();
+            try {
+                connectionSources.close();
+            } catch (IOException e) {
+                LOG.error("There was an error shutting down GORM for an entity: " + e.getMessage(), e);
+            }
             destroyed = true;
         }
     }
 
     @Override
     @PreDestroy
-    public void close() throws IOException {
+    public void close() {
         try {
             destroy();
         } catch (Exception e) {
-            throw new IOException("Error closing hibernate datastore: " + e.getMessage(), e);
+            LOG.error("Error closing hibernate datastore: " + e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
Methods annotated with `@PreDestroy` should not throw a checked exception.

This is documented at https://docs.oracle.com/javaee/7/api/javax/annotation/PreDestroy.html