### PR TITLE
Fix #1106, add a cascadeValidate mapping option to control cascading validation

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/Property.groovy
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/Property.groovy
@@ -112,7 +112,11 @@ class Property implements Cloneable {
      * property is an association or collection.
      */
     String cascade
-
+    /**
+     * Cascade validation for associations that are not owned by the parent entity. Only makes sense
+     * if the property is an association.
+     */
+    boolean cascadeValidate = true
     /**
      * For specifying the cascade type using {@link CascadeType}
      */

--- a/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/cfg/HibernateMappingBuilder.groovy
+++ b/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/cfg/HibernateMappingBuilder.groovy
@@ -460,6 +460,7 @@ class HibernateMappingBuilder implements MappingConfigurationBuilder<Mapping, Pr
             property.updatable = namedArgs.updateable != null ? namedArgs.updateable : property.updatable
             property.updatable = namedArgs.updatable != null ? namedArgs.updatable : property.updatable
             property.cascade = namedArgs.cascade ?: property.cascade
+            property.cascadeValidate = namedArgs.cascadeValidate != null ? namedArgs.cascadeValidate : property.cascadeValidate
             property.sort = namedArgs.sort ?: property.sort
             property.order = namedArgs.order ?: property.order
             property.batchSize = namedArgs.batchSize instanceof Integer ? namedArgs.batchSize : property.batchSize

--- a/grails-datastore-gorm-validation/src/test/groovy/grails/gorm/validation/PersistentEntityValidatorSpec.groovy
+++ b/grails-datastore-gorm-validation/src/test/groovy/grails/gorm/validation/PersistentEntityValidatorSpec.groovy
@@ -11,10 +11,12 @@ import org.grails.datastore.mapping.validation.ValidationErrors
 import org.grails.datastore.mapping.validation.ValidatorRegistry
 import org.springframework.validation.Errors
 import org.springframework.validation.Validator
+import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
 
 import javax.persistence.Entity
+import javax.persistence.Transient
 
 class PersistentEntityValidatorSpec extends Specification {
     @Shared Validator authorValidator
@@ -33,6 +35,7 @@ class PersistentEntityValidatorSpec extends Specification {
     }
 
     // beforeValidate on the initial save is part of the GormValidationApi doValidate() call
+    @Issue('https://github.com/grails/grails-data-mapping/issues/1102')
     def "validation of root object does NOT trigger beforeValidate here"() {
         Author author = new Author()
         Errors errors = new ValidationErrors(author)
@@ -45,6 +48,7 @@ class PersistentEntityValidatorSpec extends Specification {
         errors.getFieldErrors('name')
     }
 
+    @Issue('https://github.com/grails/grails-data-mapping/issues/1102')
     def "cascading validation triggers beforeValidate callback on to-many association"() {
         Author author = new Author(name: 'Author', books: [new Book()])
         Errors errors = new ValidationErrors(author)
@@ -58,6 +62,7 @@ class PersistentEntityValidatorSpec extends Specification {
         author.books.first().name == "name"
     }
 
+    @Issue('https://github.com/grails/grails-data-mapping/issues/1102')
     def "cascading validation triggers beforeValidate callback on to-one association"() {
         Author author = new Author(name: 'Author', publisher: new Publisher())
         Errors errors = new ValidationErrors(author)
@@ -69,25 +74,80 @@ class PersistentEntityValidatorSpec extends Specification {
         !errors.hasErrors()
         author.publisher.name == "name"
     }
+
+    @Issue('https://github.com/grails/grails-data-mapping/issues/1106')
+    def "validation does not cascade when cascadeValidate is false and not owning side"() {
+        Author author = new Author(name: 'Author', anotherPublisher: new Publisher(), publisher: new Publisher())
+        Errors errors = new ValidationErrors(author)
+
+        when:
+        authorValidator.validate(author, errors)
+
+        then: "validate was not called for this association"
+        !errors.hasErrors()
+        !author.anotherPublisher.name
+
+        and: "validate was called for this one since the default for cascadeValidate is true"
+        author.publisher.name == "name"
+    }
+
+    @Issue('https://github.com/grails/grails-data-mapping/issues/1106')
+    def "validation cascades regardless of cascadeValidate when owning side"() {
+        Author author = new Author(name: 'Author', books: [new Book()])
+        Errors errors = new ValidationErrors(author)
+
+        when:
+        authorValidator.validate(author, errors)
+
+        then: "validate is called for books"
+        !errors.hasErrors()
+        author.books.first()
+        author.books.first().name == "name"
+    }
+
+    @Issue('https://github.com/grails/grails-data-mapping/issues/1106')
+    def "validation does not cascade if not owner and cascade options are not PERSIST or MERGE"() {
+        Author author = new Author(name: 'Author', nonCascadePublisher: new Publisher())
+        Errors errors = new ValidationErrors(author)
+
+        when:
+        authorValidator.validate(author, errors)
+
+        then: "validate is not called for publisher"
+        !errors.hasErrors()
+        !author.nonCascadePublisher.name
+    }
 }
 
 @Entity
-class Author  {
+class Author {
     String name
+
     Publisher publisher
+    Publisher anotherPublisher
+    Publisher nonCascadePublisher
+
     Set<Book> books
 
     static hasMany = [books: Book]
 
     static constraints = {
         publisher(nullable: true)
+        anotherPublisher(nullable: true)
+        nonCascadePublisher(nullable: true)
+    }
+
+    static mapping = {
+        books(cascadeValidate: false) // This will be ignored since Author.isOwningSide of books
+        anotherPublisher(cascadeValidate: false)
+        nonCascadePublisher(cascade: 'none') // This will also prevent cascading validation
     }
 }
 
 @Entity
 class Book {
     String name
-    Author author
+    static belongsTo = [author: Author]
 
     def beforeValidate() {
         name = "name"
@@ -98,7 +158,18 @@ class Book {
 class Publisher {
     String name
 
+
     def beforeValidate() {
         name = "name"
+    }
+
+    // some of the persistent entity validator logic relies on errors being present
+    @Transient
+    Errors errors
+    Errors getErrors() {
+        if(errors == null) {
+            errors = new ValidationErrors(this)
+        }
+        errors
     }
 }


### PR DESCRIPTION
To prevent changing behavior by default, adds a `cascadeValidate` mapping option which can control validation cascading for non-owned associations separately from the persistence `CascadeType` options.