### PR TITLE
Fixes #1204 - MethodValidationTransformSpec fails when under non-english environment

### DIFF
--- a/grails-datastore-gorm/src/test/groovy/grails/gorm/services/MethodValidationTransformSpec.groovy
+++ b/grails-datastore-gorm/src/test/groovy/grails/gorm/services/MethodValidationTransformSpec.groovy
@@ -67,7 +67,7 @@ class Foo {
         then:
         def e = thrown( ConstraintViolationException)
         e.constraintViolations.size() == 1
-        e.constraintViolations.first().message == 'must not be null'
+        e.constraintViolations.first().messageTemplate == '{javax.validation.constraints.NotNull.message}'
         e.constraintViolations.first().propertyPath.toString() == 'find.title'
 
         when:


### PR DESCRIPTION
My suggestion for fixing the test execution of MethodValidationTransformSpec under different than English locale environment.