### PR TITLE
Fix issue for between restriction in subquery on assocation

### DIFF
--- a/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/query/AbstractHibernateCriterionAdapter.java
+++ b/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/query/AbstractHibernateCriterionAdapter.java
@@ -228,7 +228,7 @@ public abstract class AbstractHibernateCriterionAdapter {
             @Override
             public Criterion toHibernateCriterion(AbstractHibernateQuery hibernateQuery, Query.Criterion criterion, String alias) {
                 Query.Between btwCriterion = (Query.Between) criterion;
-                return Restrictions.between(calculatePropertyName(calculatePropertyName(btwCriterion.getProperty(), alias), alias), btwCriterion.getFrom(), btwCriterion.getTo());
+                return Restrictions.between(calculatePropertyName(btwCriterion.getProperty(), alias), btwCriterion.getFrom(), btwCriterion.getTo());
             }
         });
 


### PR DESCRIPTION
When a subquery is performed on an associated domain, the subquery is converted from GORM to Hibernate in the registered adapters in [AbstractHibernateCriterionAdapter](https://github.com/grails/grails-data-mapping/blob/6.1.x/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/query/AbstractHibernateCriterionAdapter.java).

The adapter for between restrictions was appending the alias (when applicable) to the property name twice.

This commit removes the duplicate alias.