### PR TITLE
Fix createNamedQuery initialization for multi-threaded environment

### DIFF
--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormEnhancer.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormEnhancer.groovy
@@ -228,20 +228,15 @@ class GormEnhancer implements Closeable {
                         def evaluator = new NamedQueriesBuilder()
                         namedQueries = evaluator.evaluate(closure)
                         NAMED_QUERIES.put(className, namedQueries)
-                        return buildNamedCriteriaProxy(entity, namedQueries, queryName, args)
                     }
                     else {
                         NAMED_QUERIES.put(className, Collections.emptyMap())
+                        return null
                     }
                 }
-
-            }
-
-        }
-        else {
-            return buildNamedCriteriaProxy(entity, namedQueries, queryName, args)
-        }
-        return null
+	    }
+        }        
+        return buildNamedCriteriaProxy(entity, namedQueries, queryName, args)
     }
 
     private static NamedCriteriaProxy buildNamedCriteriaProxy(Class entity, Map<String, Closure> namedQueries, String queryName, Object... args) {


### PR DESCRIPTION
There was a previous pull request (https://github.com/grails/grails-data-mapping/pull/1052) which addressed multi threaded issues with named criteria but was only merged into master

We are migrating a project from grails 2 ->3 and are using gorm 6.1.11 and have now hit this issue.

Can we get this fix merged into the 6.1 branch please?

(cherry picked from commit 97afa402a83cf339e88ecf3f53758bac3ac962c2)