### PR TITLE
Use equals method for dirty checking

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/dirty/checking/DirtyCheckable.groovy
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/dirty/checking/DirtyCheckable.groovy
@@ -78,7 +78,7 @@ trait DirtyCheckable {
     void markDirty(String propertyName, newValue) {
         if( $changedProperties != null && !$changedProperties.containsKey(propertyName))  {
             def oldValue = ((GroovyObject) this).getProperty(propertyName)
-            if(newValue != oldValue) {
+            if(!newValue.equals(oldValue)) {
                 $changedProperties.put propertyName, oldValue
             }
         }
@@ -91,7 +91,7 @@ trait DirtyCheckable {
      */
     void markDirty(String propertyName, newValue, oldValue) {
         if( $changedProperties != null && !$changedProperties.containsKey(propertyName))  {
-            if(newValue != oldValue) {
+            if(!newValue.equals(oldValue)) {
                 $changedProperties.put propertyName, oldValue
             }
         }

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/dirty/checking/DirtyCheckable.groovy
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/dirty/checking/DirtyCheckable.groovy
@@ -78,7 +78,9 @@ trait DirtyCheckable {
     void markDirty(String propertyName, newValue) {
         if( $changedProperties != null && !$changedProperties.containsKey(propertyName))  {
             def oldValue = ((GroovyObject) this).getProperty(propertyName)
-            if(!newValue.equals(oldValue)) {
+            if ((newValue == null && oldValue != null) ||
+                (newValue != null && oldValue == null) ||
+                (newValue && !newValue.equals(oldValue))) {
                 $changedProperties.put propertyName, oldValue
             }
         }
@@ -91,7 +93,9 @@ trait DirtyCheckable {
      */
     void markDirty(String propertyName, newValue, oldValue) {
         if( $changedProperties != null && !$changedProperties.containsKey(propertyName))  {
-            if(!newValue.equals(oldValue)) {
+            if ((newValue == null && oldValue != null) ||
+                (newValue != null && oldValue == null) ||
+                (newValue && !newValue.equals(oldValue))) {
                 $changedProperties.put propertyName, oldValue
             }
         }

--- a/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/dirty/checking/DirtyCheckableSpec.groovy
+++ b/grails-datastore-core/src/test/groovy/org/grails/datastore/mapping/dirty/checking/DirtyCheckableSpec.groovy
@@ -1,0 +1,47 @@
+package org.grails.datastore.mapping.dirty.checking
+
+
+import groovy.transform.Sortable
+import spock.lang.Issue
+import spock.lang.Specification
+
+class DirtyCheckableSpec extends Specification {
+
+    @Issue('https://github.com/grails/grails-data-mapping/issues/1231')
+    def 'setting a field that implements Comparable dirty checks properly'() {
+        given: 'a person'
+        def person = new Person(name: 'John Doe')
+
+        and: 'a blog post'
+        def blogPost = new BlogPost(title: 'Hello World', content: 'some content')
+        person.lastViewedPost = blogPost
+
+        and: 'a second blog post is made'
+        def anotherBlogPost = new BlogPost(title: blogPost.title, content: 'different content, same title')
+
+        and: 'change list is reset'
+        person.trackChanges()
+
+        when: 'the lastViewedPost is set to something different'
+        person.lastViewedPost = anotherBlogPost
+
+        and: 'markDirty is called (normally would be weaved in by a DirtyCheckingTransformer)'
+        person.markDirty('lastViewedPost', anotherBlogPost, blogPost)
+
+        then:
+        person.hasChanged()
+        person.hasChanged('lastViewedPost')
+        person.getOriginalValue('lastViewedPost').equals(blogPost)
+    }
+}
+
+class Person implements DirtyCheckable {
+    String name
+    BlogPost lastViewedPost
+}
+
+@Sortable(includes = ['title'])
+class BlogPost {
+    String title
+    String content
+}


### PR DESCRIPTION
The `==` method will always call `compareTo` if the property implements `Comparable`, which is not always desirable. Call the equals method directly instead.
Include spec illustrating the new behavior.

Addresses https://github.com/grails/grails-data-mapping/issues/1231

As always, comments welcome. I suspect there may be opinions on this subject.