### PR TITLE
improve dirty checking of new entity instances

### DIFF
--- a/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/dirty/GrailsEntityDirtinessStrategy.groovy
+++ b/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/dirty/GrailsEntityDirtinessStrategy.groovy
@@ -49,7 +49,7 @@ class GrailsEntityDirtinessStrategy implements CustomEntityDirtinessStrategy {
 
     @Override
     boolean isDirty(Object entity, EntityPersister persister, Session session) {
-        !session.contains(entity) || cast(entity).hasChanged() || DirtyCheckingSupport.areEmbeddedDirty(GormEnhancer.findEntity(Hibernate.getClass(entity)), entity)
+        !session.contains(entity) || !cast(entity).listDirtyPropertyNames().isEmpty() || DirtyCheckingSupport.areEmbeddedDirty(GormEnhancer.findEntity(Hibernate.getClass(entity)), entity)
     }
 
     @Override

--- a/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/support/ClosureEventTriggeringInterceptor.java
+++ b/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/support/ClosureEventTriggeringInterceptor.java
@@ -122,7 +122,6 @@ public class ClosureEventTriggeringInterceptor extends AbstractClosureEventTrigg
     public void onSaveOrUpdate(SaveOrUpdateEvent hibernateEvent) throws HibernateException {
         Object entity = getEntity(hibernateEvent);
         if(entity != null && proxyHandler.isInitialized(entity)) {
-            activateDirtyChecking(entity);
             org.grails.datastore.mapping.engine.event.SaveOrUpdateEvent grailsEvent = new org.grails.datastore.mapping.engine.event.SaveOrUpdateEvent(
                     this.datastore, entity);
             publishEvent(hibernateEvent, grailsEvent);


### PR DESCRIPTION
ref. grails/grails-data-mapping#1064
new entity instances are now consistently considered changed from a
DirtyCheckable point-of-view prior to postInsert