### PR TITLE
 grails/gorm-mongodb#77 Updated MultiTenantEventListener

### DIFF
--- a/grails-datastore-gorm-rx/src/main/groovy/org/grails/gorm/rx/events/MultiTenantEventListener.groovy
+++ b/grails-datastore-gorm-rx/src/main/groovy/org/grails/gorm/rx/events/MultiTenantEventListener.groovy
@@ -55,12 +55,13 @@ class MultiTenantEventListener implements PersistenceEventListener {
                         TenantId tenantId = entity.getTenantId();
                         if(tenantId != null) {
                             Serializable currentId = Tenants.currentId(datastoreClient.getClass());
-                            query.eq(tenantId.getName(), currentId );
+                            if (currentId != ConnectionSource.DEFAULT) {
+                                query.eq(tenantId.getName(), currentId );
+                            }
                         }
                     }
                 }
-            }
-            else if(event instanceof PreInsertEvent) {
+            } else if(event instanceof PreInsertEvent) {
                 PreInsertEvent preInsertEvent = (PreInsertEvent) event;
                 PersistentEntity entity = preInsertEvent.getEntity();
                 if(entity.isMultiTenant()) {

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/multitenancy/MultiTenantEventListener.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/multitenancy/MultiTenantEventListener.java
@@ -10,9 +10,7 @@ import org.grails.datastore.mapping.model.types.TenantId;
 import org.grails.datastore.mapping.multitenancy.MultiTenantCapableDatastore;
 import org.grails.datastore.mapping.multitenancy.exceptions.TenantException;
 import org.grails.datastore.mapping.query.Query;
-import org.grails.datastore.mapping.query.event.PostQueryEvent;
 import org.grails.datastore.mapping.query.event.PreQueryEvent;
-import org.grails.datastore.mapping.reflect.EntityReflector;
 import org.springframework.context.ApplicationEvent;
 
 import java.io.Serializable;
@@ -53,7 +51,7 @@ public class MultiTenantEventListener implements PersistenceEventListener {
                 Query query = preQueryEvent.getQuery();
 
                 PersistentEntity entity = query.getEntity();
-                if(entity.isMultiTenant()) {
+                if (entity.isMultiTenant()) {
                     if(datastore == null) {
                         datastore = GormEnhancer.findDatastore(entity.getJavaClass());
                     }
@@ -64,16 +62,16 @@ public class MultiTenantEventListener implements PersistenceEventListener {
 
                             if(datastore instanceof MultiTenantCapableDatastore) {
                                 currentId = Tenants.currentId((MultiTenantCapableDatastore) datastore);
-                            }
-                            else {
+                            } else {
                                 currentId = Tenants.currentId(datastore.getClass());
                             }
-                            query.eq(tenantId.getName(), currentId );
+                            if (currentId != ConnectionSource.DEFAULT) {
+                                query.eq(tenantId.getName(), currentId );
+                            }
                         }
                     }
                 }
-            }
-            else if((event instanceof ValidationEvent) || (event instanceof PreInsertEvent) || (event instanceof PreUpdateEvent)) {
+            } else if((event instanceof ValidationEvent) || (event instanceof PreInsertEvent) || (event instanceof PreUpdateEvent)) {
                 AbstractPersistenceEvent preInsertEvent = (AbstractPersistenceEvent) event;
                 PersistentEntity entity = preInsertEvent.getEntity();
                 if(entity.isMultiTenant()) {


### PR DESCRIPTION
Updated MultiTenantEventListener to not add the multi-tenant filter to the query in case of shared database and when `tenantId` is DEFAULT