### PR TITLE
Support empty list argument in dynamic finder inList only for JPA

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,10 +29,10 @@ project.ext {
     projectMajorVersion = "6"
     projectMinorVersion = "1"
     projectPatchVersion = "11"
-    //releaseType = "RELEASE"
+    releaseType = "RELEASE"
 //    releaseType = "M2"
 //    releaseType = "RC2"
-    releaseType = "BUILD-SNAPSHOT"
+//    releaseType = "BUILD-SNAPSHOT"
 
     // overall project version
     projectVersion = "${projectMajorVersion}.${projectMinorVersion}.${projectPatchVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -28,11 +28,11 @@ project.ext {
 
     projectMajorVersion = "6"
     projectMinorVersion = "1"
-    projectPatchVersion = "11"
-    releaseType = "RELEASE"
+    projectPatchVersion = "12"
+    //releaseType = "RELEASE"
 //    releaseType = "M2"
 //    releaseType = "RC2"
-//    releaseType = "BUILD-SNAPSHOT"
+    releaseType = "BUILD-SNAPSHOT"
 
     // overall project version
     projectVersion = "${projectMajorVersion}.${projectMinorVersion}.${projectPatchVersion}"

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/jpa/JpaQueryBuilder.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/query/jpa/JpaQueryBuilder.java
@@ -625,14 +625,18 @@ public class JpaQueryBuilder {
                     buildSubQuery(q, whereClause, position, parameters, conversionService, allowJoins, hibernateCompatible, subquery);
                 }
                 else {
-                    for (Iterator i = inQuery.getValues().iterator(); i.hasNext();) {
-                        Object val = i.next();
-                        whereClause.append(PARAMETER_PREFIX);
-                        whereClause.append(++position);
-                        if (i.hasNext()) {
-                            whereClause.append(COMMA);
+                    if (inQuery.getValues().isEmpty()){
+                        whereClause.append("null"); // that also always evaluates to false because NULL in sql is never equal. https://hibernate.atlassian.net/browse/HHH-8091
+                    } else {
+                        for (Iterator i = inQuery.getValues().iterator(); i.hasNext();) {
+                            Object val = i.next();
+                            whereClause.append(PARAMETER_PREFIX);
+                            whereClause.append(++position);
+                            if (i.hasNext()) {
+                                whereClause.append(COMMA);
+                            }
+                            parameters.add(conversionService.convert(val, propType));
                         }
-                        parameters.add(conversionService.convert(val, propType));
                     }
                 }
                 whereClause.append(CLOSE_BRACKET);

--- a/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/query/AbstractHibernateCriterionAdapter.java
+++ b/grails-datastore-gorm-hibernate-core/src/main/groovy/org/grails/orm/hibernate/query/AbstractHibernateCriterionAdapter.java
@@ -228,7 +228,7 @@ public abstract class AbstractHibernateCriterionAdapter {
             @Override
             public Criterion toHibernateCriterion(AbstractHibernateQuery hibernateQuery, Query.Criterion criterion, String alias) {
                 Query.Between btwCriterion = (Query.Between) criterion;
-                return Restrictions.between(calculatePropertyName(calculatePropertyName(btwCriterion.getProperty(), alias), alias), btwCriterion.getFrom(), btwCriterion.getTo());
+                return Restrictions.between(calculatePropertyName(btwCriterion.getProperty(), alias), btwCriterion.getFrom(), btwCriterion.getTo());
             }
         });
 

--- a/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/InListSpec.groovy
+++ b/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/InListSpec.groovy
@@ -1,0 +1,17 @@
+package grails.gorm.tests
+
+class InListSpec extends GormDatastoreSpec {
+
+    void "test in list returns the correct results for empty argument"() {
+        when:
+        new TestEntity(name:"Fred").save()
+        new TestEntity(name:"Bob").save()
+        new TestEntity(name:"Jack").save(flush:true)
+
+        then:
+        TestEntity.countByNameInList(['Fred', "Bob"]) == 2
+        TestEntity.countByNameInList([]) == 0
+        TestEntity.countByNameInList(null) == 0
+    }
+
+}

--- a/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/NullValueEqualSpec.groovy
+++ b/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/NullValueEqualSpec.groovy
@@ -4,13 +4,15 @@ class NullValueEqualSpec extends GormDatastoreSpec {
 
   void "test null value in equal and not equal"() {
     when:
-    new TestEntity(name:"Fred").save(failOnError: true)
+    new TestEntity(name:"Fred", age: null).save(failOnError: true)
     new TestEntity(name:"Bob", age: 11).save(failOnError: true)
-    new TestEntity(name:"Jack").save(flush:true, failOnError: true)
+    new TestEntity(name:"Jack", age: null).save(flush:true, failOnError: true)
 
     then:
-    TestEntity.countByAge(null) == 2
     TestEntity.countByAge(11) == 1
+    TestEntity.findAllByAge(null).size() == 2
+    TestEntity.countByAge(null) == 2
+
     TestEntity.countByAgeNotEqual(11) == 2
     TestEntity.countByAgeNotEqual(null) == 1
   }

--- a/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/NullValueEqualSpec.groovy
+++ b/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/NullValueEqualSpec.groovy
@@ -1,0 +1,17 @@
+package grails.gorm.tests
+
+class NullValueEqualSpec extends GormDatastoreSpec {
+
+  void "test not in list returns the correct results"() {
+    when:
+    new TestEntity(name:"Fred").save()
+    new TestEntity(name:"Bob", age: 11).save()
+    new TestEntity(name:"Jack").save(flush:true)
+
+    then:
+    TestEntity.countByAge(null) == 2
+    TestEntity.countByAge(11) == 1
+    TestEntity.countByAgeNotEqual(11) == 2
+    TestEntity.countByAgeNotEqual(null) == 1
+  }
+}

--- a/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/NullValueEqualSpec.groovy
+++ b/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/NullValueEqualSpec.groovy
@@ -2,11 +2,11 @@ package grails.gorm.tests
 
 class NullValueEqualSpec extends GormDatastoreSpec {
 
-  void "test not in list returns the correct results"() {
+  void "test null value in equal and not equal"() {
     when:
-    new TestEntity(name:"Fred").save()
-    new TestEntity(name:"Bob", age: 11).save()
-    new TestEntity(name:"Jack").save(flush:true)
+    new TestEntity(name:"Fred").save(failOnError: true)
+    new TestEntity(name:"Bob", age: 11).save(failOnError: true)
+    new TestEntity(name:"Jack").save(flush:true, failOnError: true)
 
     then:
     TestEntity.countByAge(null) == 2

--- a/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/TestEntity.groovy
+++ b/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/TestEntity.groovy
@@ -16,12 +16,13 @@ class TestEntity implements Serializable {
 
     static mapping = {
         name index:true
-        age index:true, nullable:true
-        child index:true, nullable:true
+        age index:true
+        child index:true
     }
 
     static constraints = {
         name blank:false
         child nullable:true
+        age nullable:true
     }
 }

--- a/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/validation/UniqueConstraintSpec.groovy
+++ b/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/validation/UniqueConstraintSpec.groovy
@@ -19,6 +19,7 @@ class UniqueConstraintSpec extends Specification {
             Channel,
             DefaultChannel,
             ListChannel,
+            OtherListChannel,
             Organization
     )
 
@@ -45,6 +46,23 @@ class UniqueConstraintSpec extends Specification {
 
         when: 'a new channel with the same name is created'
         def defaultChannel2 = new DefaultChannel(name: defaultChannel1.name, organization: testOrg)
+
+        then:
+        !defaultChannel2.validate()
+        defaultChannel2.hasErrors()
+        defaultChannel2.errors.getFieldError('name').code == 'unique'
+
+    }
+
+    void 'unique constraint works with parent/child/child'() {
+        given: 'an existing channel'
+        def testOrg = new Organization(name: 'Test 1')
+        testOrg.defaultChannel.organization = testOrg
+        testOrg.save(failOnError: true, flush: true)
+        def defaultChannel1 = testOrg.defaultChannel
+
+        when: 'a new channel with the same name is created'
+        def defaultChannel2 = new OtherListChannel(name: defaultChannel1.name, organization: testOrg)
 
         then:
         !defaultChannel2.validate()
@@ -127,6 +145,14 @@ class DefaultChannel extends Channel {
 
 @Entity
 class ListChannel extends Channel {
+
+    static constraints = {
+    }
+}
+
+
+@Entity
+class OtherListChannel extends ListChannel {
 
     static constraints = {
     }

--- a/grails-datastore-gorm-validation/src/main/groovy/grails/gorm/validation/PersistentEntityValidator.groovy
+++ b/grails-datastore-gorm-validation/src/main/groovy/grails/gorm/validation/PersistentEntityValidator.groovy
@@ -257,7 +257,7 @@ class PersistentEntityValidator implements CascadingValidator, ConstrainedEntity
                     continue
                 }
                 if (associatedPersistentProperty instanceof Association) {
-                    if(association.doesCascade(CascadeType.PERSIST, CascadeType.MERGE)) {
+                    if(((Association)associatedPersistentProperty).doesCascade(CascadeType.PERSIST, CascadeType.MERGE)) {
                         if(association.isBidirectional() && associatedPersistentProperty == association.inverseSide) {
                             // If this property is the inverse side of the currently processed association then
                             // we don't want to process it

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/DynamicFinder.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/DynamicFinder.java
@@ -765,11 +765,11 @@ public abstract class DynamicFinder extends AbstractFinder implements QueryBuild
      * @return the initialized expression
      */
     private MethodExpression getInitializedExpression(MethodExpression expression, Object[] arguments) {
-        if (expression instanceof Equal && arguments.length == 1 && arguments[0] == null) {
-            expression = new IsNull(expression.propertyName);
-        } else {
-            expression.setArguments(arguments);
-        }
+//        if (expression instanceof Equal && arguments.length == 1 && arguments[0] == null) { // logic moved directly to Equal.createCriterion
+//            expression = new IsNull(expression.propertyName);
+//        } else {
+        expression.setArguments(arguments);
+//        }
         return expression;
     }
 

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/MethodExpression.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/finders/MethodExpression.java
@@ -422,7 +422,12 @@ public abstract class MethodExpression {
 
         @Override
         public Query.Criterion createCriterion() {
-            return Restrictions.eq(propertyName, arguments[0]);
+            Object argument = arguments[0];
+            if (argument != null) {
+                return Restrictions.eq(propertyName, argument);
+            } else {
+                return Restrictions.isNull(propertyName);
+            }
         }
 
     }
@@ -437,7 +442,12 @@ public abstract class MethodExpression {
 
         @Override
         public Query.Criterion createCriterion() {
-            return Restrictions.ne(propertyName, arguments[0]);
+            Object argument = arguments[0];
+            if (argument != null) {
+                return Restrictions.ne(propertyName, arguments[0]);
+            } else {
+                return Restrictions.isNotNull(propertyName);
+            }
         }
 
     }

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/jdbc/connections/DataSourceConnectionSourceFactory.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/jdbc/connections/DataSourceConnectionSourceFactory.java
@@ -70,6 +70,7 @@ public class DataSourceConnectionSourceFactory extends AbstractConnectionSourceF
             String password = settings.getPassword();
             Map properties = settings.getProperties();
             String url = settings.getUrl();
+            Class type = settings.getType();
 
             if(properties != null && !properties.isEmpty()) {
                 dataSourceBuilder.properties(settings.toProperties());
@@ -82,6 +83,10 @@ public class DataSourceConnectionSourceFactory extends AbstractConnectionSourceF
             if(username != null && password != null) {
                 dataSourceBuilder.username(username);
                 dataSourceBuilder.password(password);
+            }
+
+            if (type != null) {
+                dataSourceBuilder.type(type);
             }
 
             dataSource = dataSourceBuilder.build();

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/jdbc/connections/DataSourceSettings.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/jdbc/connections/DataSourceSettings.groovy
@@ -8,6 +8,8 @@ import org.grails.datastore.gorm.jdbc.schema.DefaultSchemaHandler
 import org.grails.datastore.gorm.jdbc.schema.SchemaHandler
 import org.grails.datastore.mapping.core.connections.ConnectionSourceSettings
 
+import javax.sql.DataSource
+
 /**
  * DataSource settings
  *
@@ -87,6 +89,12 @@ class DataSourceSettings extends ConnectionSourceSettings {
      * The data source properties
      */
     Map properties = [:]
+
+    /**
+     * The connection pool to use
+     */
+    Class<? extends DataSource> type
+
     /**
      * Convert to Hibernate properties
      *

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/validation/constraints/builtin/UniqueConstraint.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/validation/constraints/builtin/UniqueConstraint.groovy
@@ -62,7 +62,7 @@ class UniqueConstraint extends AbstractConstraint {
         if (!targetEntity.isRoot()) {
             def property = targetEntity.getPropertyByName(constraintPropertyName)
             while (property.isInherited() && targetEntity != null) {
-                targetEntity = mappingContext.getPersistentEntity(mappingContext.getProxyHandler().getProxiedClass(target).superclass.getName())
+                targetEntity = mappingContext.getPersistentEntity(targetEntity.javaClass.superclass.name)
                 if (targetEntity != null) {
                     property = targetEntity.getPropertyByName(constraintPropertyName)
                 }


### PR DESCRIPTION
PR for https://github.com/grails/grails-data-mapping/issues/1212

> is the proposed fix only targeting gorm for sql/hibernate datastores? i think other non-sql databases gorm supports (e.g. mongo) may be just fine with an empty collection argument?
> 
> n.b.: spring-data-jpa seems to work around this with IN (NULL). that also always evaluates to false because NULL in sql is never equal.
> 
> https://jira.spring.io/browse/DATAJPA-606
> https://github.com/spring-projects/spring-data-jpa/blob/2.1.6.RELEASE/src/main/java/org/springframework/data/jpa/provider/PersistenceProvider.java#L103
> https://hibernate.atlassian.net/browse/HHH-8091