### PR TITLE
removing duplicate call to tenantIdentifier

### DIFF
--- a/grails-datastore-gorm/src/main/groovy/grails/gorm/multitenancy/Tenants.groovy
+++ b/grails-datastore-gorm/src/main/groovy/grails/gorm/multitenancy/Tenants.groovy
@@ -72,7 +72,7 @@ class Tenants {
             TenantResolver tenantResolver = multiTenantCapableDatastore.getTenantResolver()
             Serializable tenantIdentifier = tenantResolver.resolveTenantIdentifier()
             log.debug "Resolved tenant id [$tenantIdentifier] from resolver [${tenantResolver.getClass().simpleName}]"
-            return multiTenantCapableDatastore.getTenantResolver().resolveTenantIdentifier()
+            return tenantIdentifier
         }
     }
 


### PR DESCRIPTION
Seems like getTenantResolver call is duplicating for the each thread which seems to be  not necessary 