### PR TITLE
Groovy eclipse update

### DIFF
--- a/grails-datastore-gorm/src/main/groovy/org/grails/compiler/gorm/GroovyEclipseCompilationHelper.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/compiler/gorm/GroovyEclipseCompilationHelper.groovy
@@ -29,10 +29,16 @@ class GroovyEclipseCompilationHelper {
 	 * Attempts to resolve the compilation directory when using Eclipse
 	 *
 	 * @param sourceUnit The source unit
-	 * @return The File that represents the root directory or null
+	 * @return The File that represents the root directory or defaultPath
 	 */
-	static File resolveEclipseCompilationTargetDirectory(SourceUnit sourceUnit) {
-
+	static File resolveEclipseCompilationTargetDirectory(SourceUnit sourceUnit, final String defaultPath = null) {
+		
+		
+		// Fail fast if we don't have a compiler configuration present.
+		if (!sourceUnit.configuration) {
+			return null
+		}
+		
 		if (isGroovyEclipse(sourceUnit)) {
 			StandardEvaluationContext context = new StandardEvaluationContext()
 			context.setTypeLocator(new StandardTypeLocator(sourceUnit.getClass().getClassLoader()))
@@ -42,25 +48,31 @@ class GroovyEclipseCompilationHelper {
 				File targetDirectory = sourceUnit.configuration.targetDirectory
 
 				if (targetDirectory == null) {
-
 					// Resolve as before.
-					targetDirectory = ((File) new SpelExpressionParser().parseExpression("eclipseFile.project.getFolder(T(org.eclipse.jdt.core.JavaCore).create(eclipseFile.project).outputLocation).rawLocation.makeAbsolute().toFile().absoluteFile").getValue(context))
-
-				} else if (!targetDirectory.isAbsolute()) {
+					final String path = ((String) new SpelExpressionParser().parseExpression("""
+						eclipseFile.project.getFolder(T(org.eclipse.jdt.core.JavaCore).create(eclipseFile.project).outputLocation).rawLocation
+					""").getValue(context))
+					
+					targetDirectory = new File(path)
+					
+				}
+				
+				if (!targetDirectory.isAbsolute()) {
 					// Target directory is set and is not absolute.
 					// We should assume that this is a path relative to the current eclipse project,
 					// and needs resolving appropriately.
 					targetDirectory = ((File) new SpelExpressionParser().parseExpression("eclipseFile.project.getFolder('${targetDirectory.path}').rawLocation.makeAbsolute().toFile().absoluteFile").getValue(context))
-
+					
 				}
+				
 				// Else absolute file location. We should return as-is.
 				return targetDirectory
 			} catch (Throwable e) {
-				// Not running Eclipse IDE, probably using the Eclipse compiler with Maven
+				// Return null to denote unable to resolve and is in eclipse context.
 				return null
 			}
 		}
-		return null
+		return defaultPath ? new File(defaultPath) : null
 	}
 
 	/**
@@ -70,6 +82,7 @@ class GroovyEclipseCompilationHelper {
 	 * @return boolean true if the source unit appears to be eclipse-based, otherwise false
 	 */
 	static boolean isGroovyEclipse (final SourceUnit sourceUnit) {
-		sourceUnit.getClass().name == 'org.codehaus.jdt.groovy.control.EclipseSourceUnit'
+		// Using simple name makes this code survive repackaging.
+		sourceUnit.getClass().simpleName == 'EclipseSourceUnit'
 	}
 }

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/services/transform/ServiceTransformation.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/services/transform/ServiceTransformation.groovy
@@ -396,8 +396,9 @@ class ServiceTransformation extends AbstractTraitApplyingGormASTTransformation i
 	protected boolean shouldGenerateDescriptor (final SourceUnit sourceUnit, final ReaderSource readerSource) {
 		
 		// Don't generate for runtime compiled scripts, unless this is the groovy-eclipse JDT compiler. 
-		readerSource instanceof FileReaderSource || readerSource instanceof URLReaderSource ||
-			(GroovyEclipseCompilationHelper.isGroovyEclipse (sourceUnit) && readerSource instanceof StringReaderSource)
+		readerSource instanceof FileReaderSource ||
+			readerSource instanceof URLReaderSource ||
+			GroovyEclipseCompilationHelper.isGroovyEclipse (sourceUnit)
 	}
 
     protected void generateServiceDescriptor(SourceUnit sourceUnit, ClassNode classNode) {

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/services/transform/ServiceTransformation.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/services/transform/ServiceTransformation.groovy
@@ -394,7 +394,6 @@ class ServiceTransformation extends AbstractTraitApplyingGormASTTransformation i
     }
 	
 	protected boolean shouldGenerateDescriptor (final SourceUnit sourceUnit, final ReaderSource readerSource) {
-		
 		// Don't generate for runtime compiled scripts, unless this is the groovy-eclipse JDT compiler. 
 		readerSource instanceof FileReaderSource ||
 			readerSource instanceof URLReaderSource ||
@@ -408,41 +407,45 @@ class ServiceTransformation extends AbstractTraitApplyingGormASTTransformation i
         if (shouldGenerateDescriptor(sourceUnit, readerSource)) {
 			
             File targetDirectory = resolveCompilationTargetDirectory(sourceUnit, 'build/resources/main')
-            File servicesDir = new File(targetDirectory, "META-INF/services")
-            servicesDir.mkdirs()
-
-            String className = classNode.name
-            try {
-                def descriptor = new File(servicesDir, org.grails.datastore.mapping.services.Service.name)
-                if (descriptor.exists()) {
-                    String ls = System.getProperty('line.separator')
-                    String contents = descriptor.text
-                    def entries = contents.split('\\n')
-                    if (!entries.contains(className)) {
-                        descriptor.append("${ls}${className}")
-                    }
-                } else {
-                    descriptor.text = className
-                }
-            } catch (Throwable e) {
-                warning(sourceUnit, classNode, "Error generating service loader descriptor for class [${className}]: $e.message")
-            }
+			
+			// targetDirectory could be null when in groovy-eclipse and if we were unable to
+			// resolve a valid directory.
+			if (targetDirectory) {
+	            File servicesDir = new File(targetDirectory, "META-INF/services")
+	            servicesDir.mkdirs()
+	
+	            String className = classNode.name
+	            try {
+	                def descriptor = new File(servicesDir, org.grails.datastore.mapping.services.Service.name)
+	                if (descriptor.exists()) {
+	                    String ls = System.getProperty('line.separator')
+	                    String contents = descriptor.text
+	                    def entries = contents.split('\\n')
+	                    if (!entries.contains(className)) {
+	                        descriptor.append("${ls}${className}")
+	                    }
+	                } else {
+	                    descriptor.text = className
+	                }
+	            } catch (Throwable e) {
+	                warning(sourceUnit, classNode, "Error generating service loader descriptor for class [${className}]: $e.message")
+	            }
+			}
         }
     }
 	
 	protected File resolveCompilationTargetDirectory(final SourceUnit source, final String defaultPath) {
 		File targetDirectory = null
-		
-		if(GroovyEclipseCompilationHelper.isGroovyEclipse (source) ) {
-			targetDirectory = GroovyEclipseCompilationHelper.resolveEclipseCompilationTargetDirectory(source)
+		if( GroovyEclipseCompilationHelper.isGroovyEclipse (source) ) {
+			targetDirectory = GroovyEclipseCompilationHelper.resolveEclipseCompilationTargetDirectory(source, defaultPath)
 		} else {
 			targetDirectory = source.configuration.targetDirectory
+			// If we could not use config to set the target directory, then we should use the supplied default.
+			if (targetDirectory == null) {
+				targetDirectory = new File(defaultPath)
+			}
 		}
 		
-		// If we could not use config to set the target directory, then we should use the supplied default.
-		if(targetDirectory == null) {
-			targetDirectory = new File(defaultPath)
-		}
 		return targetDirectory
 	}
 }


### PR DESCRIPTION
After updating to the latest Eclipse and groovy eclipse version. The Dataservices transformations stopped working again. This is because we were testing for a particular reader source type when in Groovy eclipse. Groovy eclipse recently reworked to use their own reader type, so I have removed this check. I have also reworked the checks a little.