### PR TITLE
Fix issue with empty JNDI name

### DIFF
--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/jdbc/connections/DataSourceConnectionSourceFactory.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/jdbc/connections/DataSourceConnectionSourceFactory.java
@@ -47,7 +47,7 @@ public class DataSourceConnectionSourceFactory extends AbstractConnectionSourceF
     public ConnectionSource<DataSource, DataSourceSettings> create(String name, DataSourceSettings settings) {
 
         DataSource dataSource;
-        if(settings.getJndiName() != null) {
+        if(settings.getJndiName() != null && !settings.getJndiName().isEmpty()) {
             JndiObjectFactoryBean jndiObjectFactoryBean = new JndiObjectFactoryBean();
             jndiObjectFactoryBean.setExpectedType(DataSource.class);
             jndiObjectFactoryBean.setJndiName(settings.getJndiName());


### PR DESCRIPTION
Only create JndiObjectFactoryBean when `jndiName` is not null or empty.

Fixes #1260