### PR TITLE
Fix 1294

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/dirty/checking/DirtyCheckable.groovy
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/dirty/checking/DirtyCheckable.groovy
@@ -78,10 +78,10 @@ trait DirtyCheckable {
     void markDirty(String propertyName, newValue) {
         if( $changedProperties != null && !$changedProperties.containsKey(propertyName))  {
             def oldValue = ((GroovyObject) this).getProperty(propertyName)
-             boolean isNull = newValue == null
-            if ((isNull && oldValue != null) ||
+            boolean isNull = newValue == null
+            if ((!isNull && oldValue != null) ||
                 (!isNull && oldValue == null) ||
-                (!isNull && !newValue.equals(oldValue))) {
+                (!isNull && !newValue.equals(_unwrapValue(oldValue)))) {
                 $changedProperties.put propertyName, oldValue
             }
         }
@@ -97,7 +97,7 @@ trait DirtyCheckable {
             boolean isNull = newValue == null
             if ((isNull && oldValue != null) ||
                 (!isNull && oldValue == null) ||
-                (!isNull && !newValue.equals(oldValue))) {
+                (!isNull && !newValue.equals(_unwrapValue(oldValue)))) {
                 $changedProperties.put propertyName, oldValue
             }
         }
@@ -131,5 +131,9 @@ trait DirtyCheckable {
         } else {
             return null
         }
+    }
+
+    private Object _unwrapValue(Object val) {
+        return val instanceof EntityProxy ? ((EntityProxy) val).getTarget() : val
     }
 }

--- a/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/DirtyCheckingSpec.groovy
+++ b/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/DirtyCheckingSpec.groovy
@@ -1,14 +1,21 @@
 package org.grails.datastore.gorm
 
+import grails.gorm.annotation.Entity
 import grails.gorm.tests.GormDatastoreSpec
 
 import grails.gorm.tests.Person
 import org.grails.datastore.mapping.dirty.checking.DirtyCheckable
+import org.grails.datastore.mapping.proxy.EntityProxy
 
 /**
  * @author Graeme Rocher
  */
 class DirtyCheckingSpec extends GormDatastoreSpec {
+
+    @java.lang.Override
+    List getDomainClasses() {
+        return [TestAuthor, TestBook]
+    }
 
     void "Test that dirty checking methods work when changing entities"() {
         when:"A new instance is created"
@@ -53,4 +60,107 @@ class DirtyCheckingSpec extends GormDatastoreSpec {
 
 
     }
+
+    void "test relationships not marked dirty when proxies are used"() {
+        given:
+        Long id
+        Long authorId
+
+        TestBook.withNewTransaction {
+            TestBook.withSession {
+                TestAuthor author = new TestAuthor(name: 'Jose Hernandez')
+                TestBook book = new TestBook(title: 'Martin Fierro', author: author)
+                book.save(flush: true, failOnError: true)
+                id = book.id
+                authorId = author.id
+            }
+        }
+
+        when:
+        TestAuthor author
+        TestBook book1
+
+        TestBook.withNewTransaction {
+            TestBook.withNewSession {
+                book1 = TestBook.get(id)
+                author = book1.author
+                book1.author = author
+            }
+        }
+
+        then:
+        isProxy(author)
+        !book1.isDirty('author')
+        !book1.isDirty()
+
+        cleanup:
+        TestBook.withNewTransaction {
+            TestBook.withSession {
+                TestAuthor.get(authorId)?.delete()
+                TestBook.get(id)?.delete()
+            }
+        }
+    }
+
+    void "test relationships not marked dirty when domain objects are used"() {
+        given:
+        Long id
+        Long authorId
+
+        TestBook.withNewTransaction {
+            TestBook.withSession {
+                TestAuthor author = new TestAuthor(name: 'Jose Hernandez')
+                TestBook book = new TestBook(title: 'Martin Fierro', author: author)
+                book.save(flush: true, failOnError: true)
+                id = book.id
+                authorId = author.id
+            }
+        }
+
+        when:
+        TestAuthor author
+        TestBook book1
+
+        TestBook.withNewTransaction {
+            TestBook.withNewSession {
+                book1 = TestBook.get(id)
+                author = TestAuthor.get(authorId)
+                book1.author = author
+
+            }
+        }
+
+        then:
+        !isProxy(author)
+        !book1.isDirty('author')
+        !book1.isDirty()
+
+        cleanup:
+        TestBook.withNewTransaction {
+            TestBook.withSession {
+                TestAuthor.get(authorId)?.delete()
+                TestBook.get(id)?.delete()
+            }
+        }
+    }
+
+    private boolean isProxy(def item) {
+        return item instanceof EntityProxy
+    }
+}
+
+@Entity
+class TestAuthor {
+
+    String name
+    long version
+
+}
+
+@Entity
+class TestBook {
+
+    String title
+    long version
+    TestAuthor author
 }


### PR DESCRIPTION
Unwraps oldvalue, If it is needed, before to do the dirty check. To avoid relationships one to one that are using proxies, will be incorrectly marked as dirty.