### PR TITLE
#1368 - respect FactoryBean.getObjectType contract, use context…

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/DatastoreServiceMethodInvokingFactoryBean.groovy
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/DatastoreServiceMethodInvokingFactoryBean.groovy
@@ -22,7 +22,10 @@ class DatastoreServiceMethodInvokingFactoryBean extends MethodInvokingFactoryBea
 
     @Override
     Class<?> getObjectType() {
-        arguments[0] as Class<?>
+        if (arguments) {
+            return arguments[0] as Class<?>
+        }
+        return null
     }
 
     @Override

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/DatastoreServiceMethodInvokingFactoryBean.groovy
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/DatastoreServiceMethodInvokingFactoryBean.groovy
@@ -22,10 +22,10 @@ class DatastoreServiceMethodInvokingFactoryBean extends MethodInvokingFactoryBea
 
     @Override
     Class<?> getObjectType() {
-        if (arguments) {
+        if (arguments != null && arguments.size() == 1) {
             return arguments[0] as Class<?>
         }
-        return null
+        return super.getObjectType()
     }
 
     @Override

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/services/SoftServiceLoader.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/services/SoftServiceLoader.java
@@ -88,7 +88,7 @@ public final class SoftServiceLoader<S> implements Iterable<ServiceDefinition<S>
      * @return A new service loader
      */
     public static <S> SoftServiceLoader<S> load(Class<S> service) {
-        return SoftServiceLoader.load(service, SoftServiceLoader.class.getClassLoader());
+        return SoftServiceLoader.load(service, Thread.currentThread().getContextClassLoader());
     }
 
     /**

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/bootstrap/AbstractDatastoreInitializer.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/bootstrap/AbstractDatastoreInitializer.groovy
@@ -333,8 +333,7 @@ abstract class AbstractDatastoreInitializer implements ResourceLoaderAware{
 
     private Class<?> loadServiceClass(Class<Service> clazz) {
         final String serviceClassName = clazz.package.getName() + '.' + clazz.simpleName[1..-15]
-        final ClassLoader cl = org.grails.datastore.mapping.reflect.ClassUtils.classLoader
-        final Class<?> serviceClass = cl.loadClass(serviceClassName)
+        final Class<?> serviceClass = classLoader.loadClass(serviceClassName)
         serviceClass
     }
 


### PR DESCRIPTION
…classloader where appropriate

- `DatastoreServiceMethodInvokingFactoryBean.getObjectType` returns null if not initialized (i.e. `arguments` is `null`, `getArguments()` returns `Object[]`). that allows `AbstractAutowireCapableBeanFactory` to initialize `DatastoreServiceMethodInvokingFactoryBean` if necessary

- `AbstractDatastoreInitializer` and `SoftServiceLoader` use the context classloader to load data service classes. this way, autowiring data services by type works reliably with spring boot devtools restart (`RestartClassLoader`)

@puneetbehl primarily for review by you.  

after i fixed `DatastoreServiceMethodInvokingFactoryBean.getObjectType` locally and ran the sample app, i still got a `NoSuchBeanDefinitionException` although i could see the bean definition..  

after some fun debugging in, i saw that it was again classloader-related: 2 different instances of `interface DummyDataService` being compared by `DefaultListableBeanFactory.findAutowireCandidates`/`ClassUtils.isAssignable`: one by `AppClassLoader`, the other one by `RestartClassLoader`.

do you have a suggestion how to properly unit/integration test this? i saw grails/gorm-hibernate5/examples/test-data-service but the tests do not use the restart classloader anyway, right?

thanks for taking a look.