### PR TITLE
Remove MVCC from hardcoded default H2 connection string

### DIFF
--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/jdbc/connections/DataSourceSettings.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/jdbc/connections/DataSourceSettings.groovy
@@ -21,7 +21,7 @@ class DataSourceSettings extends ConnectionSourceSettings {
     /**
      * The data source URL, defaults to an H2 in-memory database
      */
-    String url = "jdbc:h2:mem:grailsDB;MVCC=TRUE;LOCK_TIMEOUT=10000"
+    String url = "jdbc:h2:mem:grailsDB;LOCK_TIMEOUT=10000"
 
     /**
      * The driver class name

--- a/grails-datastore-gorm/src/test/groovy/grails/gorm/annotation/transactions/TransactionalTransformSpec.groovy
+++ b/grails-datastore-gorm/src/test/groovy/grails/gorm/annotation/transactions/TransactionalTransformSpec.groovy
@@ -785,7 +785,7 @@ new BookService()
     }
 
     TestTransactionManager getPlatformTransactionManager() {
-        def dataSource = new DriverManagerDataSource("jdbc:h2:mem:${TransactionalTransformSpec.name};MVCC=TRUE;LOCK_TIMEOUT=10000", "sa", "")
+        def dataSource = new DriverManagerDataSource("jdbc:h2:mem:${TransactionalTransformSpec.name};LOCK_TIMEOUT=10000", "sa", "")
 
         // this may not be necessary...
         dataSource.driverClassName = "org.h2.Driver"


### PR DESCRIPTION
H2 version 1.4.200 removed the MVCC configuration, so remove from hardcoded default configuration.