### PR TITLE
feat(core): Exclude domain for specific data sources in Multi Tenancy

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/multitenancy/TenantDataSourceConfig.java
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/multitenancy/TenantDataSourceConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grails.datastore.mapping.multitenancy;
+
+import java.lang.annotation.*;
+
+/**
+ * <p>An annotation that adds possibility to configure whether a domain should be excluded from particular
+ * data source(s). For example:</p>
+ *
+ * <pre>
+ * {@literal @}TenantDataSourceConfig(dataSourcesToExclude=["adminDataSource"])
+ * class Animal implements MultiTenant<Animal> {
+ *       ...
+ * }
+ * </pre>
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface TenantDataSourceConfig {
+    String[] dataSourcesToExclude() default "";
+}


### PR DESCRIPTION
…tasource to be used by multi-tenancy.

At the moment, when MultiTenant trait is added to a domain, the domain is automatically added to all data sources in application.
But sometimes it can be helpful to have possibility exclude such domain from a data source. E.g. in case when application has some "admin" database, which should contain only specific domains (without those with MultiTenant trait).

This annotation add possibility to define for which data sources domain should be excluded.