### PR TITLE
update scale constraint to prevent marking objects dirty when nothing has changed

### DIFF
--- a/grails-datastore-gorm-validation/src/main/groovy/org/grails/datastore/gorm/validation/constraints/ScaleConstraint.java
+++ b/grails-datastore-gorm-validation/src/main/groovy/org/grails/datastore/gorm/validation/constraints/ScaleConstraint.java
@@ -123,7 +123,10 @@ public class ScaleConstraint extends AbstractConstraint {
      * @param originalValue The original value
      */
     private BigDecimal getScaledValue(BigDecimal originalValue) {
-        return originalValue.setScale(scale, BigDecimal.ROUND_HALF_UP);
+        if (originalValue.scale() > scale) {
+            return originalValue.setScale(scale, BigDecimal.ROUND_HALF_UP);
+        }
+        return originalValue;
     }
 }
 


### PR DESCRIPTION
This makes the scale constraint work like the documentation describes it at https://docs.grails.org/latest/ref/Constraints/scale.html so that the scale is only updated if it is larger than the constraint value.
