### PR TITLE
Update Java CI Workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -69,6 +69,6 @@ jobs:
         with:
           workflow: Java CI
           repo: grails/gorm-hibernate5
-          ref: master
+          ref: ${{ steps.extract_branch.outputs.value }}
           token: ${{ secrets.GH_TOKEN }}
           inputs: ${{ steps.dispatch_message.outputs.value }}


### PR DESCRIPTION
Remove the hardcoded ref value from the "Invoke the Java CI workflow in GORM Hibernate5" step.