### PR TITLE
Update DirtyCheckingSupport

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/dirty/checking/DirtyCheckable.groovy
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/dirty/checking/DirtyCheckable.groovy
@@ -86,6 +86,9 @@ trait DirtyCheckable {
      */
     void markDirty(String propertyName) {
         if( $changedProperties != null && !$changedProperties.containsKey(propertyName))  {
+            if (DirtyCheckingSupport.DIRTY_CLASS_MARKER.is($changedProperties)) {
+                trackChanges()
+            }
             $changedProperties.put propertyName, ((GroovyObject)this).getProperty(propertyName)
         }
     }
@@ -113,6 +116,9 @@ trait DirtyCheckable {
             if ((isNull && oldValue != null) ||
                     (!isNull && oldValue == null) ||
                     (!isNull && !newValue.equals(oldValue))) {
+                if (DirtyCheckingSupport.DIRTY_CLASS_MARKER.is($changedProperties)) {
+                    trackChanges()
+                }
                 $changedProperties.put propertyName, oldValue
             }
         }

--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/dirty/checking/DirtyCheckingSupport.groovy
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/dirty/checking/DirtyCheckingSupport.groovy
@@ -37,7 +37,7 @@ class DirtyCheckingSupport {
     /**
      * Used internally as a marker. Do not use in user code
      */
-    public static final  Map DIRTY_CLASS_MARKER = [:]
+    public static final  Map DIRTY_CLASS_MARKER = [:].asImmutable()
     /**
      * Checks whether associations are dirty
      *


### PR DESCRIPTION
Initialize DIRTY_CLASS_MARKER as Immutable collection, as marker should not be modified
Fixes #1462

Signed-off-by: Puneet Behl <behlp@objectcomputing.com>