### PR TITLE
Update DatastoreServiceMethodInvokingFactoryBean

### DIFF
--- a/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/DatastoreServiceMethodInvokingFactoryBean.groovy
+++ b/grails-datastore-core/src/main/groovy/org/grails/datastore/mapping/config/DatastoreServiceMethodInvokingFactoryBean.groovy
@@ -17,15 +17,18 @@ import org.springframework.lang.Nullable
 @CompileStatic
 class DatastoreServiceMethodInvokingFactoryBean extends MethodInvokingFactoryBean {
 
+    private Class<?> serviceClass
+
+    DatastoreServiceMethodInvokingFactoryBean(Class<?> serviceClass) {
+        this.serviceClass = serviceClass
+    }
+
     @Nullable
     private ConfigurableBeanFactory beanFactory
 
     @Override
     Class<?> getObjectType() {
-        if (arguments != null && arguments.size() == 1) {
-            return arguments[0] as Class<?>
-        }
-        return super.getObjectType()
+        return serviceClass
     }
 
     @Override

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/bootstrap/AbstractDatastoreInitializer.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/bootstrap/AbstractDatastoreInitializer.groovy
@@ -292,7 +292,7 @@ abstract class AbstractDatastoreInitializer implements ResourceLoaderAware{
             }
             loadDataServices(null)
                     .each {serviceName, serviceClass->
-                "$serviceName"(DatastoreServiceMethodInvokingFactoryBean) {
+                "$serviceName"(DatastoreServiceMethodInvokingFactoryBean, serviceClass) {
                     targetObject = ref("${type}Datastore")
                     targetMethod = 'getService'
                     arguments = [serviceClass]


### PR DESCRIPTION
Previously, the getObjectType method was returning NULL because the closure in AbstractDatastoreInitializer is not called earlier in the bean processing. So, in order to resolve
the type the AbstractBeanFactory initialize the MethodInvokingFactoryBean which results in initializing objectDefinitionSource(AnnotaionFilterInvocationDefinition) early before creating servletContext.

Fixes grails/grails-core#12057