### PR TITLE
Improvements to GORM DirtyCheckingTransformer to properly handle both Boolean and boolean type properties

### DIFF
--- a/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/GormDirtyCheckingSpec.groovy
+++ b/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/GormDirtyCheckingSpec.groovy
@@ -2,12 +2,13 @@ package org.grails.datastore.gorm
 
 import grails.gorm.annotation.Entity
 import grails.gorm.tests.GormDatastoreSpec
+import spock.lang.Issue
 
 class GormDirtyCheckingSpec extends GormDatastoreSpec {
 
     @Override
     List getDomainClasses() {
-        [Student]
+        [Student, BooleanTest]
     }
 
     void "test a new instance is dirty by default"() {
@@ -19,9 +20,29 @@ class GormDirtyCheckingSpec extends GormDatastoreSpec {
         student.isDirty()
     }
 
+    @Issue('https://github.com/grails/grails-core/issues/12453')
+    void "test Boolean property getters"() {
+
+        when:
+        BooleanTest student = new BooleanTest(property1: true, property2: true)
+
+        then: "Same behaviour of getters for boolean and Boolean"
+        student.isProperty1()
+        student.getProperty1()
+        student.isProperty2()
+        student.getProperty2()
+    }
+
 }
 
 @Entity
 class Student {
     String name
 }
+
+@Entity
+class BooleanTest {
+    Boolean property1
+    boolean property2
+}
+

--- a/grails-datastore-gorm/src/main/groovy/org/grails/compiler/gorm/DirtyCheckingTransformer.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/compiler/gorm/DirtyCheckingTransformer.groovy
@@ -206,7 +206,7 @@ class DirtyCheckingTransformer implements CompilationUnitAware {
 
                     // first add the getter
                     ClassNode returnType = resolvePropertyReturnType(pn, classNode)
-                    boolean booleanProperty = ClassHelper.boolean_TYPE.getName().equals(returnType.getName())
+                    boolean booleanProperty = ClassHelper.boolean_TYPE.getName().equals(returnType.getName()) || ClassHelper.Boolean_TYPE.getName().equals(returnType.getName())
                     String fieldName = propertyField.getName()
                     String getterName = NameUtils.getGetterName(propertyName, false)
 


### PR DESCRIPTION
Small change on DirtyCheckingTransformer so getters are synthesized for Boolean properties in the same way that they are for boolean properties.

Fixes grails/grails-data-mapping#1646