### PR TITLE
GORM should not check Entity's dirtiness on formula and transient type of properties

### DIFF
--- a/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/DirtyCheckingSpec.groovy
+++ b/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/DirtyCheckingSpec.groovy
@@ -1,0 +1,73 @@
+import grails.gorm.annotation.Entity
+import grails.gorm.tests.GormDatastoreSpec
+
+class DirtyCheckingSpec extends GormDatastoreSpec {
+    
+    void "When marking whole class dirty, then derived and transient properties are still not dirty"() {
+        when:
+        TestBook book = new TestBook()
+        book.title = "Test"
+        and: "mark class as not dirty - to clear previous dirty tracking"
+        book.trackChanges()
+
+        then:
+        !book.hasChanged()
+
+        when: "Mark whole class as dirty"
+        book.markDirty()
+
+        then: "whole class is dirty"
+        book.hasChanged()
+
+        and: "The formula and transient properties are not dirty"
+        !book.hasChanged('formulaProperty')
+        !book.hasChanged('transientProperty')
+        
+        and: "Other properties are"
+        book.hasChanged('id')
+        book.hasChanged('title')
+
+    }
+
+    void "Test that dirty tracking doesn't apply on Entity's transient properties"() {
+        when:
+        TestBook book = new TestBook()
+        book.title = "Test"
+        and: "mark class as not dirty, clear previous dirty tracking"
+        book.trackChanges()
+
+        then:
+        !book.hasChanged()
+
+        when: "update transient property"
+        book.transientProperty = "new transient value"
+
+        then: "class is not dirty"
+        !book.hasChanged()
+
+        and: "transient properties are not dirty"
+        !book.hasChanged('transientProperty')
+    }
+
+    @Override
+    List getDomainClasses() {
+        [TestBook]
+    }
+}
+
+@Entity
+class TestBook implements Serializable {
+
+    Long id
+    String title
+
+    String formulaProperty
+
+    String transientProperty
+    
+    static mapping = {
+        formulaProperty(formula: 'name || \' (formula)\'')
+    }
+    
+    static transients = ['transientProperty']
+}

--- a/grails-datastore-gorm/src/main/groovy/org/grails/compiler/gorm/GormEntityTransformation.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/compiler/gorm/GormEntityTransformation.groovy
@@ -56,6 +56,7 @@ import org.codehaus.groovy.transform.AbstractASTTransformation
 import org.codehaus.groovy.transform.GroovyASTTransformation
 import org.grails.datastore.gorm.GormEnhancer
 import org.grails.datastore.gorm.GormEntity
+import org.grails.datastore.gorm.GormEntityDirtyCheckable
 import org.grails.datastore.gorm.query.GormQueryOperations
 import org.grails.datastore.mapping.model.config.GormProperties
 import org.grails.datastore.mapping.reflect.AstUtils
@@ -240,7 +241,7 @@ class GormEntityTransformation extends AbstractASTTransformation implements Comp
 
         // now apply dirty checking behavior
         def dirtyCheckTransformer = new DirtyCheckingTransformer()
-        dirtyCheckTransformer.performInjectionOnAnnotatedClass(sourceUnit, classNode)
+        dirtyCheckTransformer.performInjectionOnAnnotatedClass(sourceUnit, classNode, GormEntityDirtyCheckable)
 
 
         // convert the methodMissing and propertyMissing implementations to $static_methodMissing and $static_propertyMissing for the static versions

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormEntityDirtyCheckable.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormEntityDirtyCheckable.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.grails.datastore.gorm
+
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import org.grails.datastore.mapping.config.Property
+import org.grails.datastore.mapping.dirty.checking.DirtyCheckable
+import org.grails.datastore.mapping.model.PersistentEntity
+import org.grails.datastore.mapping.model.PersistentProperty
+
+import javax.annotation.Generated
+
+/**
+ *
+ * Special trait meant only for GORM entities to override default behaviour of DirtyCheckable.
+ * Applied manually during GormEntity transformation
+ *
+ * @since 7.3
+ */
+@CompileStatic
+trait GormEntityDirtyCheckable extends DirtyCheckable {
+    
+    @Override
+    @Generated
+    boolean hasChanged(String propertyName) {
+        PersistentEntity entity = currentGormInstanceApi().persistentEntity
+        
+        PersistentProperty persistentProperty = entity.getPropertyByName(propertyName)
+        if (!persistentProperty) {
+            // Not persistent property, transient. We don't track changes for transients 
+            return false
+        }
+        
+        Property propertyMapping = persistentProperty.getMapping().getMappedForm() 
+        if (propertyMapping.derived) {
+            // Derived property cannot be changed, ex. sql formula
+            return false
+        }
+
+        return super.hasChanged(propertyName)
+    }
+
+    @Generated
+    private GormInstanceApi currentGormInstanceApi() {
+        (GormInstanceApi) GormEnhancer.findInstanceApi(getClass())
+    }
+}


### PR DESCRIPTION
Fix for issue #1708

> When using "formula" kind of property on GORM entity and marking whole class as dirty, then during entity's save GORM Hibernate will want to include "formula" also into update clause. Hibernate ignores it, but started to log about such situations on WARN level: "HHH000502: The [_formula_kind_property_name_] property of the [_entity_class_name_] entity was modified, but it won't be updated because the property is immutable." For workaround, I will make sure that only changed properties are marked dirty and will not use method to mark whole class as dirty. But it would be nice to be able to use markDirty on whole class, with formulas.

It could be handled at GORM Hibernate side, but I decided to handle it on GORM side - not to tell/track changes for derived(ex. formula) and transient properties.

For GORM entities, dirtiness check is added "manually" during AST transformation, not through trait (fix for [#1126](https://github.com/grails/grails-data-mapping/issues/1126)). So I couldn't simply extend or override dirty checks in GormEntity trait. That's why I created new trait GormEntityDirtyCheckable, which i will add "manually" during AST transformation. Maybe someone who is better in metaprogramming/tranformation could do it with the trait.