### PR TITLE
Remove deprecated set-output command

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -59,11 +59,11 @@ jobs:
       - name: Extract branch name
         if: steps.publish.outcome == 'success' && github.event_name == 'push' && matrix.java == '8'
         id: extract_branch
-        run: echo ::set-output name=value::${GITHUB_REF:11}
+        run: echo "value=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
       - name: Create Snapshot Message for the Workflow Dispatch
         if: success() && github.event_name == 'push' && matrix.java == '8'
         id: dispatch_message
-        run: echo ::set-output name=value::{\"message\":\"New Core Snapshot $(date) - $GITHUB_SHA\"}
+        run: echo "value={\"message\":\"New Core Snapshot $(date) - $GITHUB_SHA\"}" >> $GITHUB_OUTPUT
       - name: Invoke the Java CI workflow in GORM Hibernate5
         if: success() && github.event_name == 'push' && matrix.java == '8'
         uses: benc-uk/workflow-dispatch@v1.2

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -16,10 +16,10 @@ jobs:
         id: check_release_drafter
         run: |
           has_release_drafter=$([ -f .github/release-drafter.yml ] && echo "true" || echo "false")
-          echo ::set-output name=has_release_drafter::${has_release_drafter}
+          echo "has_release_drafter=${has_release_drafter}" >> $GITHUB_OUTPUT
       - name: Extract branch name
         id: extract_branch
-        run: echo ::set-output name=value::${GITHUB_REF:11}
+        run: echo "value=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
       # If it has release drafter:
       - uses: release-drafter/release-drafter@v5
         if: steps.check_release_drafter.outputs.has_release_drafter == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,10 @@ jobs:
           echo "Determining Target Branch"
           TARGET_BRANCH=`cat $GITHUB_EVENT_PATH | jq '.release.target_commitish' | sed -e 's/^"\(.*\)"$/\1/g'`
           echo $TARGET_BRANCH
-          echo ::set-output name=value::${TARGET_BRANCH}
+          echo "value=${TARGET_BRANCH}" >> $GITHUB_OUTPUT
       - name: Set the current release version
         id: release_version
-        run: echo ::set-output name=release_version::${GITHUB_REF:11}
+        run: echo "release_version=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
       - name: Run pre-release
         uses: micronaut-projects/github-actions/pre-release@master
         with:
@@ -71,7 +71,7 @@ jobs:
         if: steps.assemble.outcome == 'success'
         id: gorm_docs_release_message
         run: |
-          echo ::set-output name=value::{\"gorm_version\":\"$RELEASE_VERSION\"}
+          echo "value={\"gorm_version\":\"$RELEASE_VERSION\"}" >> $GITHUB_OUTPUT
         env:
           RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}
       - name: Invoke gorm-docs release workflow


### PR DESCRIPTION
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/