### PR TITLE
Add getTotalCount() tests for sorting parameters

### DIFF
--- a/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/PagedResultSpec.groovy
+++ b/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/PagedResultSpec.groovy
@@ -2,6 +2,15 @@ package grails.gorm.tests
 
 class PagedResultSpec extends GormDatastoreSpec {
 
+    void "Test that a getTotalCount will return 0 on empty result from the list() method"() {
+        when:"A query is executed that returns no results"
+            def results = Person.list(max:1)
+
+        then:
+            results.size() == 0
+            results.totalCount == 0
+    }
+
     void "Test that a paged result list is returned from the list() method with pagination params"() {
         given:"Some people"
             createPeople()
@@ -17,16 +26,17 @@ class PagedResultSpec extends GormDatastoreSpec {
             results.totalCount == 6
     }
 
-    void "Test that a getTotalCount will return 0 on empty result"() {
+    void "Test that a getTotalCount will return 0 on empty result from the criteria"() {
         given:"Some people"
             createPeople()
 
         when:"A query is executed that returns no results"
-            def results = Person.createCriteria().list(max: 1) { 
-                eq 'lastName', 'NotFound' 
+            def results = Person.createCriteria().list(max: 1) {
+                eq 'lastName', 'NotFound'
             }
-        
+
         then:
+            results.size() == 0
             results.totalCount == 0
     }
 

--- a/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/PagedResultSpec.groovy
+++ b/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/PagedResultSpec.groovy
@@ -26,6 +26,21 @@ class PagedResultSpec extends GormDatastoreSpec {
             results.totalCount == 6
     }
 
+    void "Test that a paged result list is returned from the list() method with pagination and sorting params"() {
+        given:"Some people"
+            createPeople()
+
+        when:"The list method is used with pagination params"
+            def results = Person.list(offset:2, max:2, sort:'firstName', order:'DESC')
+
+        then:"You get a paged result list back"
+            results.getClass().simpleName == 'PagedResultList' // Grails/Hibernate has a custom class in different package
+            results.size() == 2
+            results[0].firstName == "Homer"
+            results[1].firstName == "Fred"
+            results.totalCount == 6
+    }
+
     void "Test that a getTotalCount will return 0 on empty result from the criteria"() {
         given:"Some people"
             createPeople()
@@ -54,6 +69,23 @@ class PagedResultSpec extends GormDatastoreSpec {
             results.size() == 2
             results[0].firstName == "Marge"
             results[1].firstName == "Bart"
+            results.totalCount == 4
+    }
+
+    void "Test that a paged result list is returned from the critera with pagination and sorting params"() {
+        given:"Some people"
+            createPeople()
+
+        when:"The list method is used with pagination params"
+            def results = Person.createCriteria().list(offset:1, max:2, sort:'firstName', order:'DESC') {
+                eq 'lastName', 'Simpson'
+            }
+
+        then:"You get a paged result list back"
+            results.getClass().simpleName == 'PagedResultList' // Grails/Hibernate has a custom class in different package
+            results.size() == 2
+            results[0].firstName == "Lisa"
+            results[1].firstName == "Homer"
             results.totalCount == 4
     }
 


### PR DESCRIPTION
This is to check that a `getTotalCount()` implementation should not have sorting in the generated query.
Otherwise, depending on the database and its strictness configuration, the query might fail.

In the [gorm-hibernate5](https://github.com/grails/gorm-hibernate5) project one test would fail a follows:
```
org.h2.jdbc.JdbcSQLSyntaxErrorException: Order by expression "UPPER(PERSON0_.FIRST_NAME)" must be in the result list in this case; SQL statement:
select distinct count(person0_.id) as col_0_0_ from person person0_ order by upper(person0_.first_name) desc [90068-200]
```

I will also provide a fix for it.