### PR TITLE
Fix initialization of `ValidatedService.validatorFactory`

### DIFF
--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/validation/javax/services/ValidatedService.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/validation/javax/services/ValidatedService.groovy
@@ -1,5 +1,6 @@
 package org.grails.datastore.gorm.validation.javax.services
 
+import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.grails.datastore.gorm.validation.javax.ConstraintViolationUtils
 import org.grails.datastore.gorm.validation.javax.JavaxValidatorRegistry
@@ -35,6 +36,7 @@ trait ValidatedService<T> extends Service<T> {
      */
     private ValidatorFactory validatorFactory
 
+    @CompileDynamic
     private Map<Method, ExecutableValidator> executableValidatorMap = new LinkedHashMap<Method, ExecutableValidator>().withDefault {
         getValidatorFactory().getValidator().forExecutables()
     }

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/validation/javax/services/ValidatedService.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/validation/javax/services/ValidatedService.groovy
@@ -1,6 +1,5 @@
 package org.grails.datastore.gorm.validation.javax.services
 
-import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.grails.datastore.gorm.validation.javax.ConstraintViolationUtils
 import org.grails.datastore.gorm.validation.javax.JavaxValidatorRegistry
@@ -34,18 +33,17 @@ trait ValidatedService<T> extends Service<T> {
     /**
      * The validator factory
      */
-    private ValidatorFactory validatorFactory
+    private ValidatorFactory validatorFactoryInstance
 
-    @CompileDynamic
     private Map<Method, ExecutableValidator> executableValidatorMap = new LinkedHashMap<Method, ExecutableValidator>().withDefault {
-        getValidatorFactory().getValidator().forExecutables()
+        validatorFactory.getValidator().forExecutables()
     }
 
     /**
      * @return The validator factory for this service
      */
     ValidatorFactory getValidatorFactory() {
-        if(validatorFactory == null) {
+        if(validatorFactoryInstance == null) {
 
             Configuration configuration
             if(datastore != null) {
@@ -62,9 +60,9 @@ trait ValidatedService<T> extends Service<T> {
             if(parameterNameProvider != null) {
                 configuration = configuration.parameterNameProvider(parameterNameProvider)
             }
-            validatorFactory = configuration.buildValidatorFactory()
+            validatorFactoryInstance = configuration.buildValidatorFactory()
         }
-        return validatorFactory
+        return validatorFactoryInstance
     }
 
     /**

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/validation/javax/services/ValidatedService.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/validation/javax/services/ValidatedService.groovy
@@ -36,7 +36,7 @@ trait ValidatedService<T> extends Service<T> {
     private ValidatorFactory validatorFactory
 
     private Map<Method, ExecutableValidator> executableValidatorMap = new LinkedHashMap<Method, ExecutableValidator>().withDefault {
-        validatorFactory.getValidator().forExecutables()
+        getValidatorFactory().getValidator().forExecutables()
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/grails/grails-core/issues/13349

Initialization of `ValidatedService.validatorFactory` was [accidentally bypassed in a recent PR](https://github.com/grails/grails-data-mapping/pull/1754/files#diff-f95f3a2eebd3cc98981ab1ff4b4676e505ef97f47202436ad3fdba0bc4e6d8b0R39):

```groovy
ValidatorFactory getValidatorFactory() {
    if(validatorFactory == null) {
        // validator factory initialized here
    }
    return validatorFactory
}
```

As a result of that, data services cannot validate arguments anymore, throwing NPE.