### PR TITLE
chore(ci): improve release-drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -97,9 +97,6 @@ categories:
       - 'ci'
       - 'perf'
       - 'build'
-      - 'deps'
-      - "type: dependency upgrade"
-      - "dependencies"
       - "type: ci"
       - "type: build"
   - title: '⏪ Reverts'


### PR DESCRIPTION
Remove labels, "type: dependency upgrade", deps, and dependencies from the Maintenance category.