### PR TITLE
Cleanup & fix annotation reading for classpath scanning

### DIFF
--- a/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/InheritanceSpec.groovy
+++ b/grails-datastore-gorm-tck/src/main/groovy/grails/gorm/tests/InheritanceSpec.groovy
@@ -1,7 +1,5 @@
 package grails.gorm.tests
 
-import spock.lang.Ignore
-
 import grails.persistence.Entity
 
 /**

--- a/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/BidirectionalOneToManyWithInheritanceSpec.groovy
+++ b/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/BidirectionalOneToManyWithInheritanceSpec.groovy
@@ -1,7 +1,5 @@
 package org.grails.datastore.gorm
 
-import spock.lang.Ignore
-
 import grails.gorm.tests.GormDatastoreSpec
 import grails.persistence.Entity
 

--- a/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/InheritanceWithOneToManySpec.groovy
+++ b/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/InheritanceWithOneToManySpec.groovy
@@ -1,7 +1,5 @@
 package org.grails.datastore.gorm
 
-import spock.lang.Ignore
-
 import grails.gorm.tests.GormDatastoreSpec
 import grails.persistence.Entity
 

--- a/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/validation/UniqueConstraintSpec.groovy
+++ b/grails-datastore-gorm-test/src/test/groovy/org/grails/datastore/gorm/validation/UniqueConstraintSpec.groovy
@@ -1,7 +1,5 @@
 package org.grails.datastore.gorm.validation
 
-import spock.lang.Ignore
-
 import grails.gorm.annotation.Entity
 import grails.gorm.transactions.Transactional
 import org.grails.datastore.gorm.validation.constraints.MappingContextAwareConstraintFactory

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/utils/AnnotationMetadataReader.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/utils/AnnotationMetadataReader.java
@@ -17,6 +17,7 @@ package org.grails.datastore.gorm.utils;
 
 import org.springframework.asm.AnnotationVisitor;
 import org.springframework.asm.SpringAsmInfo;
+import org.springframework.core.annotation.AnnotationFilter;
 import org.springframework.core.io.Resource;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.core.type.ClassMetadata;
@@ -43,8 +44,8 @@ public class AnnotationMetadataReader implements MetadataReader {
      * @param resource The resource
      * @throws IOException
      */
-    AnnotationMetadataReader(Resource resource) throws IOException {
-        this.annotationMetadata = AnnotationMetadata.introspect(resource.getClass());
+    AnnotationMetadataReader(Resource resource, AnnotationFilter filter) throws IOException {
+        this.annotationMetadata = new FilteredAnnotationMetadata(resource.getClass(), filter);
         // since AnnotationMetadata extends ClassMetadata
         this.classMetadata = this.annotationMetadata;
         this.resource = resource;

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/utils/ClasspathEntityScanner.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/utils/ClasspathEntityScanner.groovy
@@ -1,4 +1,5 @@
-/* Copyright 2016 the original author or authors.
+/*
+ * Copyright 2016-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,7 +67,7 @@ class ClasspathEntityScanner {
      */
     Class[] scan(Package... packages) {
         ClassPathScanningCandidateComponentProvider componentProvider = new ClassPathScanningCandidateComponentProvider(false)
-        componentProvider.setMetadataReaderFactory(new AnnotationMetadataReaderFactory(classLoader))
+        componentProvider.setMetadataReaderFactory(new EntityAnnotationMetadataReaderFactory(classLoader))
         for(ann in annotations) {
             componentProvider.addIncludeFilter(new AnnotationTypeFilter(ann))
         }

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/utils/EntityAnnotationMetadataReaderFactory.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/utils/EntityAnnotationMetadataReaderFactory.java
@@ -1,5 +1,6 @@
 package org.grails.datastore.gorm.utils;
 
+import org.springframework.core.annotation.AnnotationFilter;
 import org.springframework.core.io.Resource;
 import org.springframework.core.type.classreading.CachingMetadataReaderFactory;
 import org.springframework.core.type.classreading.MetadataReader;
@@ -9,13 +10,13 @@ import java.io.IOException;
 /**
  * A {@link CachingMetadataReaderFactory} that only reads annotations and not the whole class body
  */
-class AnnotationMetadataReaderFactory extends CachingMetadataReaderFactory {
-    public AnnotationMetadataReaderFactory(ClassLoader classLoader) {
+class EntityAnnotationMetadataReaderFactory extends CachingMetadataReaderFactory {
+    public EntityAnnotationMetadataReaderFactory(ClassLoader classLoader) {
         super(classLoader);
     }
 
     @Override
     public MetadataReader getMetadataReader(Resource resource) throws IOException {
-        return new AnnotationMetadataReader(resource);
+        return new AnnotationMetadataReader(resource, AnnotationFilter.packages("grails.gorm.annotation", "grails.persistence", "jakarta.persistence"));
     }
 }

--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/utils/FilteredAnnotationMetadata.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/utils/FilteredAnnotationMetadata.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2002-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.grails.datastore.gorm.utils;
+
+import org.springframework.core.annotation.*;
+import org.springframework.core.type.*;
+import org.springframework.lang.Nullable;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * {@link AnnotationMetadata} implementation that uses standard reflection
+ * to introspect a given {@link Class}.
+ *
+ * <p>Note: this class was ported to GORM 9 from Spring Framework 6.1 since the package filter can't be passed to the spring version.</p>
+ *
+ * @author Juergen Hoeller
+ * @author Mark Fisher
+ * @author Chris Beams
+ * @author Phillip Webb
+ * @author Sam Brannen
+ * @since 2.5
+ * @deprecated As of Spring Framework 6.1, this class does not allow specifying the annotation filter.  An upstream pull request should be opened so this can be removed.
+ */
+@Deprecated
+public class FilteredAnnotationMetadata extends StandardClassMetadata implements AnnotationMetadata {
+    private final MergedAnnotations mergedAnnotations;
+
+    @Nullable
+    private Set<String> annotationTypes;
+
+
+    /**
+     * Create a new {@code StandardAnnotationMetadata} wrapper for the given Class.
+     * @param introspectedClass the Class to introspect
+     */
+    public FilteredAnnotationMetadata(Class<?> introspectedClass, AnnotationFilter filter) {
+        super(introspectedClass);
+        this.mergedAnnotations = MergedAnnotations.from(introspectedClass,
+                MergedAnnotations.SearchStrategy.INHERITED_ANNOTATIONS, RepeatableContainers.none(), filter);
+    }
+
+
+    @Override
+    public MergedAnnotations getAnnotations() {
+        return this.mergedAnnotations;
+    }
+
+    @Override
+    public Set<String> getAnnotationTypes() {
+        Set<String> annotationTypes = this.annotationTypes;
+        if (annotationTypes == null) {
+            annotationTypes = Collections.unmodifiableSet(AnnotationMetadata.super.getAnnotationTypes());
+            this.annotationTypes = annotationTypes;
+        }
+        return annotationTypes;
+    }
+
+    @Override
+    @Nullable
+    public Map<String, Object> getAnnotationAttributes(String annotationName, boolean classValuesAsString) {
+        return AnnotatedElementUtils.getMergedAnnotationAttributes(
+                getIntrospectedClass(), annotationName, classValuesAsString, false);
+    }
+
+    @Override
+    @Nullable
+    public MultiValueMap<String, Object> getAllAnnotationAttributes(String annotationName, boolean classValuesAsString) {
+        return AnnotatedElementUtils.getAllAnnotationAttributes(
+                getIntrospectedClass(), annotationName, classValuesAsString, false);
+    }
+
+    @Override
+    public boolean hasAnnotatedMethods(String annotationName) {
+        if (AnnotationUtils.isCandidateClass(getIntrospectedClass(), annotationName)) {
+            try {
+                Method[] methods = org.springframework.util.ReflectionUtils.getDeclaredMethods(getIntrospectedClass());
+                for (Method method : methods) {
+                    if (isAnnotatedMethod(method, annotationName)) {
+                        return true;
+                    }
+                }
+            }
+            catch (Throwable ex) {
+                throw new IllegalStateException("Failed to introspect annotated methods on " + getIntrospectedClass(), ex);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Set<MethodMetadata> getAnnotatedMethods(String annotationName) {
+        Set<MethodMetadata> result = new LinkedHashSet<>(4);
+        if (AnnotationUtils.isCandidateClass(getIntrospectedClass(), annotationName)) {
+            org.springframework.util.ReflectionUtils.doWithLocalMethods(getIntrospectedClass(), method -> {
+                if (isAnnotatedMethod(method, annotationName)) {
+                    result.add(new StandardMethodMetadata(method));
+                }
+            });
+        }
+        return result;
+    }
+
+    @Override
+    public Set<MethodMetadata> getDeclaredMethods() {
+        Set<MethodMetadata> result = new LinkedHashSet<>(16);
+        ReflectionUtils.doWithLocalMethods(getIntrospectedClass(), method ->
+                result.add(new StandardMethodMetadata(method)));
+        return result;
+    }
+
+
+    private static boolean isAnnotatedMethod(Method method, String annotationName) {
+        return !method.isBridge() && method.getAnnotations().length > 0 &&
+                AnnotatedElementUtils.isAnnotated(method, annotationName);
+    }
+}

--- a/grails-datastore-gorm/src/test/groovy/org/grails/compiler/gorm/EntityWithGenericSignaturesSpec.groovy
+++ b/grails-datastore-gorm/src/test/groovy/org/grails/compiler/gorm/EntityWithGenericSignaturesSpec.groovy
@@ -1,7 +1,5 @@
 package org.grails.compiler.gorm
 
-import spock.lang.Ignore
-
 import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValueMappingContext
 import org.grails.datastore.mapping.keyvalue.mapping.config.KeyValuePersistentEntity
 import org.grails.datastore.mapping.model.MappingContext


### PR DESCRIPTION
I've been debugging the gorm-hibernate5 tests and discovered that any classpath based initialization of the HibernateDatastore was failing.  @jamesfredley changed the `AnnotationMetadataReader` to use the helper `AnnotationMetadata.from()` from Spring.  It was failing because this helper restricts to the spring & java packages.  

For now, I've copied their StandardMetadata implementation and enhanced it to take an annotation filter, which I can then use to initialize `AnnotationMetadataReaderFactory` properly.  I renamed `AnnotationMetadataReaderFactory` to reflect it's only for entities since I'm now passing that filter explicitly.  From searching the grails repos, I don't see any other usage of it.  I hope to open an upstream PR with spring to see if they'll accept an additional argument to specify custom annotation filters.

This PR also removes some left over imports from the inheritance fixes & it fixes an ignored test - the $target method added by the AST transformation is now found by the groovy getObjectProperties in DefaultJsonGenerator, which causes a stackoverflow since it's recursive.  This may be a larger issue for json in groovy4, but for now I've explicitly ignored the found field to fix the test.  I assume most people will be using Jackson and will just igore it as part of converting to Grails 7.
