### PR TITLE
Part 1 fix of #1155 - validate(args) should be consistent with validate()

### DIFF
--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormValidateable.groovy
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/GormValidateable.groovy
@@ -67,11 +67,7 @@ trait GormValidateable {
      * @return True if the instance is valid
      */
     boolean validate(Map arguments) {
-        if(!shouldSkipValidation()) {
-            currentGormValidationApi().validate this, arguments
-        } else {
-            return true
-        }
+        currentGormValidationApi().validate this, arguments
     }
 
     /**
@@ -81,11 +77,7 @@ trait GormValidateable {
      * @return True if the instance is valid
      */
     boolean validate(List fields) {
-        if(!shouldSkipValidation()) {
-            currentGormValidationApi().validate this, fields
-        } else {
-            return true
-        }
+        currentGormValidationApi().validate this, fields
     }
 
     /**


### PR DESCRIPTION
I'm looking into fixing #1155 and part 1 of that fix is to make the validate calls consistent.  I'm removing the skipValidate check for validate(args) methods to match the validate() method.  The validate method won't be called by the event listeners since they check skip validation there.