### PR TITLE
Improve to Java CI workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -65,6 +65,7 @@ jobs:
     if: github.event_name == 'push'
     needs: [build, publish]
     runs-on: ubuntu-24.04
+    continue-on-error: true
     steps:
       - name: "📝 Store the target branch"
         id: extract_branch
@@ -78,12 +79,14 @@ jobs:
         run: echo "value={\"message\":\"New Data Mapping Snapshots $(date) - $GITHUB_SHA\"}" >> $GITHUB_OUTPUT
       - name: "📡 Invoke the Java CI workflow in GORM Hibernate5"
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4 (Use commit sha as this is a 3rd party action)
+        continue-on-error: true
         with:
           workflow: Java CI
           repo: grails/gorm-hibernate5
           ref: ${{ steps.extract_branch.outputs.value }}
           token: ${{ secrets.GH_TOKEN }}
       - name: "📡 Invoke the Java CI workflow in GORM Hibernate6"
+        continue-on-error: true
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4 (Use commit sha as this is a 3rd party action)
         with:
           workflow: Java CI
@@ -91,6 +94,7 @@ jobs:
           ref: ${{ steps.extract_branch.outputs.value }}
           token: ${{ secrets.GH_TOKEN }}
       - name: "📡 Invoke the Java CI workflow in GORM MongoDB"
+        continue-on-error: true
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4 (Use commit sha as this is a 3rd party action)
         with:
           workflow: Java CI
@@ -99,6 +103,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
           inputs: ${{ steps.dispatch_message.outputs.value }}
       - name: "📡 Invoke the Java CI workflow in GORM Neo4j"
+        continue-on-error: true
         uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # v1.2.4 (Use commit sha as this is a 3rd party action)
         with:
           workflow: Java CI

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -58,7 +58,8 @@ jobs:
           GRADLE_PUBLISH_RELEASE: 'false'
           MAVEN_PUBLISH_USERNAME: ${{ secrets.MAVEN_PUBLISH_USERNAME }}
           MAVEN_PUBLISH_PASSWORD: ${{ secrets.MAVEN_PUBLISH_PASSWORD }}
-          MAVEN_PUBLISH_URL: ${{ secrets.MAVEN_PUBLISH_SNAPSHOT_URL }}
+          # NOTE: secrets.MAVEN_PUBLISH_URL == https://repo.grails.org/grails/plugins3-snapshot-local
+          MAVEN_PUBLISH_URL: https://repo.grails.org/grails/libs-snapshots-local
         run: ./gradlew --no-build-cache publish
   trigger-build-gorm-impls:
     if: github.event_name == 'push'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,6 +8,7 @@ on:
       - '[7-9]+.[0-9]+.x'
 jobs:
   build:
+    name: "Build Project"
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -35,6 +36,7 @@ jobs:
         run: ./gradlew build --continue
   publish:
     if: github.event_name == 'push'
+    name: "Publish Snapshot"
     needs: build
     runs-on: ubuntu-24.04
     permissions:
@@ -63,6 +65,7 @@ jobs:
         run: ./gradlew --no-build-cache publish
   trigger-build-gorm-impls:
     if: github.event_name == 'push'
+    name: "Trigger Build in GORM Implementations"
     needs: [build, publish]
     runs-on: ubuntu-24.04
     continue-on-error: true


### PR DESCRIPTION
This PR enhances the Java CI workflow to improve clarity and functionality. Each commit includes a detailed description of the specific changes made. Key improvements include:

- Publish snapshots to `libs-snapshots-local` instead of  `plugins3-snapshots-local`.
- Configure `continue-on-error` for specific jobs and steps to prevent unnecessary workflow failures.
- Adding descriptive job names for better readability in the GitHub Actions interface.

Please refer to individual commit messages for more details on the changes.