### PR TITLE
Update Project dependencies and Publishing

### DIFF
--- a/gradle/publish-config.gradle
+++ b/gradle/publish-config.gradle
@@ -2,7 +2,8 @@ import org.grails.gradle.plugin.publishing.GrailsPublishExtension
 
 apply plugin: 'org.grails.grails-publish'
 
-project.extensions.configure(GrailsPublishExtension) {
+extensions.configure(GrailsPublishExtension) {
+    // Explicit `it` is required here
     it.githubSlug = 'grails/grails-data-mapping'
     it.license.name = 'Apache-2.0'
     it.title = findProperty('pomTitle') ?: 'Grails GORM'
@@ -15,4 +16,19 @@ project.extensions.configure(GrailsPublishExtension) {
             'puneetbehl': 'Puneet Behl',
             'jamesfredley': 'James Fredley'
     ]
+}
+
+// Add sources and javadoc jar tasks
+// java.withSourcesJar() and java.withJavadocJar() is not compatible here with GrailsPublishPlugin
+if (!tasks.findByName('sourcesJar')) {
+    tasks.register('sourcesJar', Jar) {
+        archiveClassifier = 'sources'
+        from sourceSets.main.allSource
+    }
+}
+if (!tasks.findByName('javadocJar')) {
+    tasks.register('javadocJar', Jar) {
+        archiveClassifier = 'javadoc'
+        from javadoc.destinationDir
+    }
 }

--- a/grails-datastore-gorm-tck/build.gradle
+++ b/grails-datastore-gorm-tck/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     }
 
     implementation 'org.grails:grails-core', {
-        // impl: ValidationException
+        // impl: Entity, ValidationException
         if (excludeUnusedTransDeps) {
             // API dependencies in grails-core
             exclude group: 'jakarta.annotation', module: 'jakarta.annotation-api'

--- a/grails-datastore-gorm-test/build.gradle
+++ b/grails-datastore-gorm-test/build.gradle
@@ -62,13 +62,11 @@ dependencies {
         // api: SelectClasses, Suite
     }
     testImplementation project(':grails-datastore-gorm-tck')
-/*
-    testCompileOnly 'org.grails:grails-core', {
-        // api: Entity
-        // impl: ValidationException
+    testImplementation 'org.grails:grails-core', {
+        // impl: Entity. ValidationException
         if (excludeUnusedTransDeps) {
             // API dependencies in grails-core
-            //exclude group: 'jakarta.annotation', module: 'jakarta.annotation-api' // PostConstruct
+            exclude group: 'jakarta.annotation', module: 'jakarta.annotation-api'
             exclude group: 'jakarta.inject', module: 'jakarta.inject-api'
             exclude group: 'jakarta.persistence', module: 'jakarta.persistence-api'
             //exclude group: 'org.grails', module: 'grails-bootstrap' // Resource
@@ -82,7 +80,6 @@ dependencies {
             exclude group: 'org.springframework.boot', module: 'spring-boot-autoconfigure'
         }
     }
-*/
     testImplementation 'org.spockframework:spock-core'
 
     // Commented out since we aren't building / publishing

--- a/grails-datastore-gorm/build.gradle
+++ b/grails-datastore-gorm/build.gradle
@@ -40,24 +40,6 @@ dependencies {
     api 'jakarta.persistence:jakarta.persistence-api', {
         // api: FetchType, JoinType
     }
-    api 'org.grails:grails-core', {
-        // ast: grails.persistence.Entity
-        if (excludeUnusedTransDeps) {
-            // API dependencies in grails-core
-            exclude group: 'jakarta.annotation', module: 'jakarta.annotation-api'
-            exclude group: 'jakarta.inject', module: 'jakarta.inject-api'
-            exclude group: 'jakarta.persistence', module: 'jakarta.persistence-api'
-            //exclude group: 'org.grails', module: 'grails-bootstrap' // Resource
-            exclude group: 'org.grails', module: 'grails-datastore-core'
-            exclude group: 'org.grails', module: 'grails-spring'
-            exclude group: 'org.springframework', module: 'spring-beans'
-            exclude group: 'org.springframework', module: 'spring-context'
-            exclude group: 'org.springframework', module: 'spring-core'
-            exclude group: 'org.springframework', module: 'spring-tx'
-            exclude group: 'org.springframework.boot', module: 'spring-boot'
-            exclude group: 'org.springframework.boot', module: 'spring-boot-autoconfigure'
-        }
-    }
     api 'org.springframework:spring-context', {
         // api: Validator
     }


### PR DESCRIPTION
The `grails-datastore-gorm` module does not require an `api` dependency on `grails-core`. This change removes the unnecessary dependency to align with the module's actual requirements and prevent potential issues.

The `sources` and `javadoc` jars are also missing from the publication. This PR adds them explicitly.

