### PR TITLE
Include javadoc & groovydoc in the same jar and restore source inclusion

### DIFF
--- a/gradle/publish-config.gradle
+++ b/gradle/publish-config.gradle
@@ -17,18 +17,3 @@ extensions.configure(GrailsPublishExtension) {
             'jamesfredley': 'James Fredley'
     ]
 }
-
-// Add sources and javadoc jar tasks
-// java.withSourcesJar() and java.withJavadocJar() is not compatible here with GrailsPublishPlugin
-if (!tasks.findByName('sourcesJar')) {
-    tasks.register('sourcesJar', Jar) {
-        archiveClassifier = 'sources'
-        from sourceSets.main.allSource
-    }
-}
-if (!tasks.findByName('javadocJar')) {
-    tasks.register('javadocJar', Jar) {
-        archiveClassifier = 'javadoc'
-        from javadoc.destinationDir
-    }
-}


### PR DESCRIPTION
@matrei  with the gradle plugin fixes, we can now restore the source & javadoc jars.  We still need to include the groovydoc in the javadoc jar though.  This may make sense to be part of a gradle plugin.

Also, with the changes to the gradle plugin, anyone who was one off registering a jar task but not including the javadoc task, will be missing sources.  I am going to enhance the gradle plugin to handle these scenarios so they are included in either case.