### PR TITLE
refactor: improve the tck process to be lazy evaluated

### DIFF
--- a/gradle/tck-config.gradle
+++ b/gradle/tck-config.gradle
@@ -1,32 +1,45 @@
+configurations {
+    tck {
+        transitive = false
+    }
+
+    // Because we reference tests in the SimpleTestSuite to be able to run them in the IDE,
+    // the tests need explicitly added to the classpath as well
+    testImplementation.extendsFrom(tck)
+}
+
 dependencies {
     if (!project.hasProperty('includeBaseTckClass') || project.findProperty('includeBaseTckClass')) {
         testImplementation project(':grails-datastore-gorm-tck-base')
     }
-    testImplementation project(':grails-datastore-gorm-tck')
+    // So we can easily extract the compiled classes
+    tck project(':grails-datastore-gorm-tck')
     testImplementation project(':grails-datastore-gorm-tck-domains')
+
+    runtimeOnly 'org.apache.groovy:groovy-dateutil', {
+        // Groovy Date Utils Extensions are used in the tests
+    }
 }
 
-// TODO: gradle will happily put the jar file on the classpath, but junit won't find the tests.  Dynamic test discovery also won't find them.
-tasks.register('extractTckJar', Copy) {
-    dependsOn(configurations.testRuntimeClasspath)
+// TODO: gradle will happily put the jar file on the classpath, but junit won't find the tests.
+//  Dynamic test discovery also won't find them so extract the class files to force junit to work.
+TaskProvider<Sync> extractTck = tasks.register('extractTckJar', Sync) {
+    inputs.files(configurations.tck)
 
-    Provider<Directory> extractTarget = layout.buildDirectory.dir('extracted-tck-classes')
-
-    doFirst {
-        extractTarget.get().asFile.deleteDir()
-    }
-
-    outputs.dir(extractTarget)
-    File tckJar = configurations.testRuntimeClasspath.resolve().find { it.name.startsWith("grails-datastore-gorm-tck-${projectVersion}") }
-    if (tckJar) {
-        from(zipTree(tckJar))
-        into(extractTarget)
-    }
+    from { zipTree(configurations.tck.singleFile) }
+    into(layout.buildDirectory.dir('extracted-tck-classes'))
 }
 
 tasks.withType(Test).configureEach {
-    dependsOn('extractTckJar')
-    doFirst {
-        testClassesDirs += files(layout.buildDirectory.dir('extracted-tck-classes'))
+    testClassesDirs = objects.fileCollection().from(extractTck, testClassesDirs)
+    finalizedBy('cleanupTckClasses')
+}
+
+// There is a known issue with IntelliJ that can cause it's inspection process to lock up.
+// this is a work around to help prevent the scenario that causes the lock up.
+tasks.register('cleanupTckClasses') {
+    Provider<Directory> extractDir = layout.buildDirectory.dir('extracted-tck-classes')
+    doLast {
+        extractDir.get().asFile.deleteDir()
     }
 }


### PR DESCRIPTION
I was speaking to https://github.com/vampire in the Gradle slack and he had some feedback on my original tck implementation.  I think I implemented them the way he suggested so they're lazy and the task does not occur at configuration time.  

Some highlights of that conversation:
1. configurations are just file collections, so you can take advantage of this.
2. If only one dependency is exported, then singleFile is a way to avoid looping over files / hard coding a name check.
3. The original code was doing configuration resolution at configuration time which has known drawbacks.  
4. It's better to use an artifact transform or instead of using tasks like Copy/Sync, use `copy { ... }` or `sync { ... }` in a `doFirst` or `doLast` block.
5. `resolve()` is 99.87% of the time the wrong solution.
6. `Copy` or `copy { ... }` should almost 98.7% of the time be `Sync` or `sync { ... } ` to not risk leaving stale files lying around.

@matrei with this new found education from an amazing developer, I thought I'd improve my original implementation =)