### PR TITLE
AutoTimestamp annotation support for non persistent super classes

### DIFF
--- a/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/events/AutoTimestampEventListener.java
+++ b/grails-datastore-gorm/src/main/groovy/org/grails/datastore/gorm/events/AutoTimestampEventListener.java
@@ -155,14 +155,13 @@ public class AutoTimestampEventListener extends AbstractPersistenceEventListener
         return properties == null ? null : properties.orElse(null);
     }
 
-    private static Field getFieldFromHierarchy(PersistentEntity persistentEntity, String fieldName) {
-        Class<?> clazz = persistentEntity.getJavaClass();
+    private static Field getFieldFromHierarchy(Class<?> entity, String fieldName) {
+        Class<?> clazz = entity;
         while (clazz != null) {
             try {
                 return clazz.getDeclaredField(fieldName);
             } catch (NoSuchFieldException e) {
-                persistentEntity = persistentEntity.getParentEntity();
-                clazz = persistentEntity == null? null : persistentEntity.getJavaClass();
+                clazz = clazz.getSuperclass();
             }
         }
         return null;
@@ -179,7 +178,7 @@ public class AutoTimestampEventListener extends AbstractPersistenceEventListener
                     } else if (property.getName().equals(DATE_CREATED_PROPERTY)) {
                         storeTimestampAvailability(entitiesWithDateCreated, persistentEntity, property);
                     } else {
-                        Field field = getFieldFromHierarchy(persistentEntity, property.getName());
+                        Field field = getFieldFromHierarchy(persistentEntity.getJavaClass(), property.getName());
                         if (field != null && field.isAnnotationPresent(AutoTimestamp.class)) {
                             AutoTimestamp autoTimestamp = field.getAnnotation(AutoTimestamp.class);
                             if (autoTimestamp.value() == AutoTimestamp.EventType.UPDATED) {


### PR DESCRIPTION
Previously annotations would only be detected if the super class was another domain class. 

This allows a domain class to have parent class that is not a domain class and still utilized the `@AutoTimestamp` annotation

e.g. this now works and does not work without this fix
`src/main/groovy/example/Media.groovy`
```groovy
class Media {
     @AutoTimestamp Date modified
}
```

`grails-app/domain/example/Image.groovy`
```groovy
class Image extends Media {
     String format
}
```

`grails-app/domain/example/Video.groovy`
```groovy
class Media extends Media {
      int frames
}
```